### PR TITLE
Improve CI caching and Playwright reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           node-version: 24
           cache: npm
+          cache-dependency-path: package-lock.json
 
       - name: Install dependencies
         run: npm ci
@@ -161,19 +162,25 @@ jobs:
       # =========================
       # Playwright E2E
       # =========================
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
 
       - name: Run E2E tests (Playwright) with JUnit
         env:
           CI: true
           PLAYWRIGHT_JUNIT_OUTPUT: artifacts/junit-playwright.xml
+          PLAYWRIGHT_HTML_OUTPUT_DIR: artifacts/playwright-report
         run: |
           mkdir -p artifacts
-          # Keep the HTML report locally; we'll only upload it if the job fails.
-          npx playwright test --reporter=line,junit,html || EXIT=$?
-          # Move the HTML report to artifacts for optional upload on failure
-          if [ -d playwright-report ]; then mv playwright-report artifacts/playwright-report; fi
+          npx playwright test || EXIT=$?
           exit ${EXIT:-0}
 
       - name: Upload Playwright JUnit (always)

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,5 @@
 import {defineConfig, devices} from '@playwright/test';
+import type {ReporterDescription} from '@playwright/test';
 import * as dotenv from 'dotenv';
 
 // Load E2E env before anything else
@@ -6,13 +7,24 @@ dotenv.config({path: process.env.E2E_DOTENV_FILE ?? '.env.e2e'});
 
 const PORT = parseInt(process.env.APP_PORT ?? '3001', 10);
 const BASE_URL = process.env.ROOT_URL ?? `http://localhost:${PORT}`;
+const IS_CI = process.env.CI === 'true' || process.env.CI === '1';
+const HTML_REPORT_DIR = process.env.PLAYWRIGHT_HTML_OUTPUT_DIR ?? 'playwright-report';
+const junitReporter: ReporterDescription | null = process.env.PLAYWRIGHT_JUNIT_OUTPUT
+    ? ['junit', {outputFile: process.env.PLAYWRIGHT_JUNIT_OUTPUT}]
+    : IS_CI
+        ? ['junit']
+        : null;
+
+const reporters: ReporterDescription[] = IS_CI
+    ? [['line'], ...(junitReporter ? [junitReporter] : []), ['html', {open: 'never', outputFolder: HTML_REPORT_DIR}]]
+    : [['list'], ['html', {open: 'never'}]];
 
 export default defineConfig({
     testDir: 'tests/e2e',
     timeout: 30_000,
     expect: {timeout: 5_000},
     fullyParallel: true,
-    reporter: [['list'], ['html', {open: 'never'}]],
+    reporter: reporters,
     use: {
         baseURL: BASE_URL,
         trace: 'on-first-retry',


### PR DESCRIPTION
## Summary
- cache npm installs using the lockfile and reuse Playwright browser downloads to speed up the workflow
- configure Playwright reporters so CI writes the JUnit XML and HTML output directly into the artifacts folder
- fix the workflow artifact upload configuration so it no longer truncates the yaml

## Testing
- not run (CI-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913923375e883329a4a1e9d085f7d85)