### PR TITLE
Revamp invoice pool UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -137,7 +137,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -725,7 +724,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -772,7 +770,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2370,7 +2367,6 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.3.tgz",
       "integrity": "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -2511,7 +2507,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.14.tgz",
       "integrity": "sha512-4zXMWD91vBLGRtHK3YbIoFMia+1nqEz72coM42C5ETjnNCa/heoj7NT1G67iAfOqMmcfhuCZ4uNpyz8EjlAejw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.8.0"
       }
@@ -3415,7 +3410,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001737",
         "electron-to-chromium": "^1.5.211",
@@ -5766,7 +5760,6 @@
       "integrity": "sha512-Ry+p2+NLk6u8Agh5yVqELfUJvRfV51hhVBRIB5yZPY7mU0DGBmOuFG5GebZbMbm86cdQNK0fhJuDX8/1YorISQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.1.3",
         "@jest/types": "30.0.5",
@@ -6144,7 +6137,6 @@
       "integrity": "sha512-dd1ORcxQraW44Uz029TtXj85W11yvLpDuIzNOlofrC8GN+SgDlgY4BvyxJiVeuabA1t6idjNbX59jLd2oplOGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/console": "30.1.2",
         "@jest/environment": "30.1.2",
@@ -6971,6 +6963,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -8886,7 +8879,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -9005,7 +8997,6 @@
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.26.tgz",
       "integrity": "sha512-o2RrBNn3lczx1qv4j+JliVMmtkPSqEGpG0UuZkt9tCfWkoXKu8MZnjvp2GjWPll1SehwemQw6xrbVRhmOglj8Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^3.17.0",
@@ -9121,7 +9112,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/public/js/events.ts
+++ b/src/public/js/events.ts
@@ -246,10 +246,13 @@ export function initInvoiceAdmin(): void {
 
         const assignAll = poolForm.querySelector('#assignAllPools') as HTMLInputElement | null;
         const defaultBox = poolForm.querySelector('#defaultPool') as HTMLInputElement | null;
-        const registrations = poolForm.querySelector('#poolRegistrations') as HTMLSelectElement | null;
+        const registrations = Array.from(poolForm.querySelectorAll<HTMLInputElement>('input[name="registrations"]'));
         const syncDisabled = () => {
-            if (!registrations) return;
-            registrations.disabled = !!(assignAll?.checked || defaultBox?.checked);
+            const disable = !!(assignAll?.checked || defaultBox?.checked);
+            registrations.forEach((input) => {
+                input.disabled = disable;
+                if (disable) input.checked = true;
+            });
         };
         assignAll?.addEventListener('change', syncDisabled);
         defaultBox?.addEventListener('change', syncDisabled);
@@ -337,13 +340,17 @@ export function initInvoiceAdmin(): void {
     // Pool assignment checkbox handler
     document.addEventListener('change', (e: Event) => {
         const target = e.target as HTMLElement;
-        if (target.matches('.pool-assignment input[type="checkbox"]')) {
+        if (target.matches('.pool-assignment .pool-toggle')) {
             const form = target.closest('.pool-assignment') as HTMLFormElement | null;
             if (!form) return;
             const assignAll = form.querySelector('input[name="assignAll"]') as HTMLInputElement | null;
             const isDefault = form.querySelector('input[name="isDefault"]') as HTMLInputElement | null;
-            const select = form.querySelector('select[name="registrations"]') as HTMLSelectElement | null;
-            if (select) select.disabled = !!(assignAll?.checked || isDefault?.checked);
+            const registrations = Array.from(form.querySelectorAll<HTMLInputElement>('input[name="registrations"]'));
+            const disable = !!(assignAll?.checked || isDefault?.checked);
+            registrations.forEach((input) => {
+                input.disabled = disable;
+                if (disable) input.checked = true;
+            });
         }
     });
 

--- a/src/public/js/events.ts
+++ b/src/public/js/events.ts
@@ -348,8 +348,22 @@ export function initInvoiceAdmin(): void {
             const registrations = Array.from(form.querySelectorAll<HTMLInputElement>('input[name="registrations"]'));
             const disable = !!(assignAll?.checked || isDefault?.checked);
             registrations.forEach((input) => {
-                input.disabled = disable;
-                if (disable) input.checked = true;
+                if (disable) {
+                    // Store original state before modifying (only if not already stored)
+                    if (!input.hasAttribute('data-original-checked')) {
+                        input.setAttribute('data-original-checked', String(input.checked));
+                    }
+                    input.disabled = true;
+                    input.checked = true;
+                } else {
+                    // Restore original state when re-enabling
+                    input.disabled = false;
+                    if (input.hasAttribute('data-original-checked')) {
+                        const originalState = input.getAttribute('data-original-checked') ?? 'false';
+                        input.checked = originalState === 'true';
+                        input.removeAttribute('data-original-checked');
+                    }
+                }
             });
         }
     });

--- a/src/public/style/style.sass
+++ b/src/public/style/style.sass
@@ -43,12 +43,23 @@
 .select2-selection__choice
   background-color: transparent !important
 
-/* mobile tweaks for activity tables */
-@media (max-width: 576px)
-  .activity-table
-    thead th
-      font-size: 0.75rem
-      padding: .25rem .3rem
+  /* mobile tweaks for activity tables */
+  @media (max-width: 576px)
+    .activity-table
+      thead th
+        font-size: 0.75rem
+        padding: .25rem .3rem
 
-    .slot
-      padding: .25rem !important
+      .slot
+        padding: .25rem !important
+
+.invoice-scroll
+  max-height: 260px
+  overflow-y: auto
+
+.assignments-list
+  max-height: 240px
+  overflow-y: auto
+
+.pool-totals
+  background: radial-gradient(circle at top left, rgba(255,255,255,0.05), transparent)

--- a/src/public/style/style.sass
+++ b/src/public/style/style.sass
@@ -43,15 +43,15 @@
 .select2-selection__choice
   background-color: transparent !important
 
-  /* mobile tweaks for activity tables */
-  @media (max-width: 576px)
-    .activity-table
-      thead th
-        font-size: 0.75rem
-        padding: .25rem .3rem
+/* mobile tweaks for activity tables */
+@media (max-width: 576px)
+  .activity-table
+    thead th
+      font-size: 0.75rem
+      padding: .25rem .3rem
 
-      .slot
-        padding: .25rem !important
+    .slot
+      padding: .25rem !important
 
 .invoice-scroll
   max-height: 260px

--- a/src/views/event/event-view.pug
+++ b/src/views/event/event-view.pug
@@ -166,10 +166,20 @@ block content
                                 i.bi.bi-x-circle.me-1
                                 | Cancel registration
 
-            if data.participantPools && data.participantPools.length
-                +invoiceSubmission(ev.id, data.participantPools, 'participant', data.participantInvoices)
-                +participantTakeoverList(data.participantPools, data.participants)
-                +participantShareSummary(data.registration.id, data.invoicePools)
+            if data.invoicePools && data.invoicePools.length
+                .accordion.accordion-dark.mb-3#participantInvoiceAccordion
+                    .accordion-item.bg-dark.text-white.border-secondary-subtle
+                        h2.accordion-header
+                            button.accordion-button.collapsed.text-white(type="button" data-bs-toggle="collapse" data-bs-target="#participantInvoiceCollapse" aria-expanded="false")
+                                i.bi.bi-cash-coin.me-2
+                                | Invoice pools & payments
+                        #participantInvoiceCollapse.accordion-collapse.collapse
+                            .accordion-body
+                                +invoiceSubmission(ev.id, data.participantPools, 'participant', data.participantInvoices, data.invoicePools)
+                                if data.participantPools && data.participantPools.length
+                                    .mt-4
+                                        +participantTakeoverList(data.participantPools, data.participants)
+                                +participantShareSummary(data.registration.id, data.invoicePools)
     else
         .alert.alert-info.mx-1
             i.bi.bi-info-circle.me-2

--- a/src/views/event/event-view.pug
+++ b/src/views/event/event-view.pug
@@ -170,7 +170,7 @@ block content
                 .accordion.accordion-dark.mb-3#participantInvoiceAccordion
                     .accordion-item.bg-dark.text-white.border-secondary-subtle
                         h2.accordion-header
-                            button.accordion-button.collapsed.text-white(type="button" data-bs-toggle="collapse" data-bs-target="#participantInvoiceCollapse" aria-expanded="false")
+                            button.accordion-button.collapsed.text-white(type="button" data-bs-toggle="collapse" data-bs-target="#participantInvoiceCollapse" aria-expanded="false" aria-controls="participantInvoiceCollapse")
                                 i.bi.bi-cash-coin.me-2
                                 | Invoice pools & payments
                         #participantInvoiceCollapse.accordion-collapse.collapse

--- a/src/views/modules/module_invoice_pool.pug
+++ b/src/views/modules/module_invoice_pool.pug
@@ -169,7 +169,7 @@ mixin invoiceSubmission(eventId, pools, mode, invoices, allPools = [])
     .accordion.accordion-dark.mb-3#invoiceSubmission
         .accordion-item.bg-dark.text-white.border-secondary-subtle
             h2.accordion-header
-                button.accordion-button.collapsed.text-white(type="button" data-bs-toggle="collapse" data-bs-target="#invoicePoolCollapse" aria-expanded="false")
+                button.accordion-button.collapsed.text-white(type="button" data-bs-toggle="collapse" data-bs-target="#invoicePoolCollapse" aria-expanded="false" aria-controls="invoicePoolCollapse")
                     i.bi.bi-receipt.me-2
                     | Submit an invoice & history
             #invoicePoolCollapse.accordion-collapse.collapse
@@ -311,7 +311,7 @@ mixin poolAssignmentsForm(ev, pool, participants)
             input.form-check-input.pool-toggle(type="checkbox" name="isDefault" id=`default-${pool.id}` checked=!!(pool.isDefault))
             label.form-check-label(for=`default-${pool.id}`) Default for new participants
         label.form-label.mt-2(for=`assign-list-${pool.id}`) Limit to participants (disabled when default or assign to all)
-        .assignments-list.border.border-secondary-subtle.rounded-3.p-2.bg-black.text-white#`assign-list-${pool.id}`
+        .assignments-list.border.border-secondary-subtle.rounded-3.p-2.bg-black.text-white(id=`assign-list-${pool.id}`)
             if participants && participants.length
                 each p in participants
                     - const selected = pool.assignments?.some(a => a.registration?.id === p.id)

--- a/src/views/modules/module_invoice_pool.pug
+++ b/src/views/modules/module_invoice_pool.pug
@@ -46,7 +46,7 @@ mixin takeoverOverview(pool, participants, mode, options)
         h6.mb-2 Takeovers
         p.text-secondary.small.mb-2 Assign which participant covers another's share. Covered participants cannot take over other shares.
     if pool.takeovers && pool.takeovers.length
-        ul.list-group.list-group-flush.bg-dark
+        ul.list-group.list-group-flush.bg-dark.border.border-secondary-subtle.rounded-3
             each t in pool.takeovers
                 - const payerName = (participants || []).find(pt => pt.id === t.payerRegistrationId)?.name || `Participant #${t.payerRegistrationId}`
                 - const coverName = (participants || []).find(pt => pt.id === t.beneficiaryRegistrationId)?.name || `Participant #${t.beneficiaryRegistrationId}`
@@ -92,25 +92,26 @@ mixin invoiceProofLink(inv, eventId, poolId)
 mixin adminInvoiceSection(title, invoices, eventId, poolId, actions = [])
     h6 #{title}
     if invoices && invoices.length
-        table.table.table-dark.table-sm
-            thead
-                tr
-                    th Invoice
-                    th Amount
-                    th Proof
-                    if actions.length > 0
-                        th Actions
-            tbody
-                each inv in invoices
+        .table-responsive.invoice-scroll
+            table.table.table-dark.table-sm.mb-0
+                thead
                     tr
-                        td ##{inv.id}
-                        td #{inv.amount}
-                        td
-                            +invoiceProofLink(inv, eventId, poolId)
+                        th Invoice
+                        th Amount
+                        th Proof
                         if actions.length > 0
-                            td.d-flex.gap-1.flex-wrap
-                                for action in actions
-                                    button.btn.btn-success.btn-sm.text-capitalize(type="button" class=`invoice-${action}` data-pool=poolId data-id=inv.id)= action
+                            th Actions
+                tbody
+                    each inv in invoices
+                        tr
+                            td ##{inv.id}
+                            td #{inv.amount}
+                            td
+                                +invoiceProofLink(inv, eventId, poolId)
+                            if actions.length > 0
+                                td.d-flex.gap-1.flex-wrap
+                                    for action in actions
+                                        button.btn.btn-success.btn-sm.text-capitalize(type="button" class=`invoice-${action}` data-pool=poolId data-id=inv.id)= action
     else
         p.text-secondary.small.mb-0 No invoices in this section.
 
@@ -131,22 +132,23 @@ mixin adminInvoiceOverview(pool, eventId)
 mixin participantInvoiceOverview(invoices, pools, eventId)
     if invoices && invoices.length
         h6.mt-3 Your invoices
-        table.table.table-dark.table-sm
-            thead
-                tr
-                    th Pool
-                    th Amount
-                    th Status
-                    th Proof
-            tbody
-                each inv in invoices
-                    - const poolName = pools.find(p => p.id === inv.poolId)?.name || 'A closed pool'
+        .table-responsive.invoice-scroll
+            table.table.table-dark.table-sm.mb-0
+                thead
                     tr
-                        td #{poolName}
-                        td #{inv.amount}
-                        td #{inv.status}
-                        td
-                            +invoiceProofLink(inv, eventId, inv.poolId)
+                        th Pool
+                        th Amount
+                        th Status
+                        th Proof
+                tbody
+                    each inv in invoices
+                        - const poolName = pools.find(p => p.id === inv.poolId)?.name || 'A closed pool'
+                        tr
+                            td #{poolName}
+                            td #{inv.amount}
+                            td #{inv.status}
+                            td
+                                +invoiceProofLink(inv, eventId, inv.poolId)
     else
         p.text-secondary.small.mb-0 You have not submitted any invoices yet.
 
@@ -161,16 +163,18 @@ mixin invoiceOverview(mode, options)
         +participantInvoiceOverview(invoices || [], pools, eventId)
 
 //- Collapsible invoice submission area for both admins (on behalf) and participants
-mixin invoiceSubmission(eventId, pools, mode, invoices)
-    if pools && pools.length
-        .accordion.accordion-dark.mb-3#invoiceSubmission
-            .accordion-item.bg-dark.text-white.border-secondary-subtle
-                h2.accordion-header
-                    button.accordion-button.collapsed.text-white(type="button" data-bs-toggle="collapse" data-bs-target="#invoicePoolCollapse" aria-expanded="false")
-                        i.bi.bi-receipt.me-2
-                        | Submit an invoice
-                #invoicePoolCollapse.accordion-collapse.collapse
-                    .accordion-body
+mixin invoiceSubmission(eventId, pools, mode, invoices, allPools = [])
+    - const hasPools = pools && pools.length;
+    - const overviewPools = hasPools ? pools : allPools;
+    .accordion.accordion-dark.mb-3#invoiceSubmission
+        .accordion-item.bg-dark.text-white.border-secondary-subtle
+            h2.accordion-header
+                button.accordion-button.collapsed.text-white(type="button" data-bs-toggle="collapse" data-bs-target="#invoicePoolCollapse" aria-expanded="false")
+                    i.bi.bi-receipt.me-2
+                    | Submit an invoice & history
+            #invoicePoolCollapse.accordion-collapse.collapse
+                .accordion-body
+                    if hasPools
                         form#invoiceSubmitForm(data-api=`/api/event/${eventId}/invoice-pools/${pools[0].id}/submit` enctype="multipart/form-data")
                             .row.g-2
                                 .col-md-4
@@ -191,11 +195,11 @@ mixin invoiceSubmission(eventId, pools, mode, invoices)
                                 button.btn.btn-primary(type="submit")
                                     i.bi.bi-cloud-upload.me-1
                                     | Submit invoice
-                        +invoiceOverview('participant', {invoices: invoices || [], pools: pools, eventId: eventId})
-    else
-        .alert.alert-info.mx-1
-            i.bi.bi-info-circle.me-2
-            | No pools available for submission yet.
+                    else
+                        .alert.alert-info
+                            i.bi.bi-info-circle.me-2
+                            | No open pools for submissions right now.
+                    +invoiceOverview('participant', {invoices: invoices || [], pools: overviewPools, eventId: eventId})
 
 //- Participant-friendly snapshot of what they owe in closed pools
 mixin participantShareSummary(registrationId, pools)
@@ -246,48 +250,76 @@ mixin poolHeader(pool)
                 if pool.isDefault
                     span.badge.bg-primary.text-dark Default
             small.text-secondary #{pool.description || 'No description provided'}
-        .d-flex.align-items-center.gap-2
-            span.badge.bg-info.text-dark #{pool.status}
-            if pool.status === 'OPEN'
-                button.btn.btn-sm.btn-warning.pool-close(type="button" data-id=pool.id) Close pool
+        span.badge.bg-info.text-dark #{pool.status}
+
+mixin poolHeaderSummary(pool)
+    .d-flex.align-items-center.w-100.justify-content-between.flex-wrap.gap-3
+        .d-flex.flex-column.flex-grow-1
+            .d-flex.align-items-center.gap-2
+                span.fw-semibold #{pool.name}
+                if pool.isDefault
+                    span.badge.bg-primary.text-dark Default
+            small.text-secondary.mb-0 #{pool.description || 'No description provided'}
+        .d-flex.flex-column.align-items-end
+            span.badge.bg-info.text-dark.mb-1 #{pool.status}
+            small.text-secondary.d-block.text-uppercase.fw-semibold.small Full total
+            span.fs-5.fw-bold #{pool.payableAmount}
 
 //- Static stats list to keep amounts readable and reusable
 mixin poolStats(pool)
     - const assignments = pool.assignments || [];
-    ul.list-unstyled.mb-0.small
-        li.mb-1
-            strong Total invoices:
-            |  #{pool.totalAmount}
-        li.mb-1
-            strong Open invoices:
-            |  #{pool.openAmount}
-        li.mb-1
-            strong Additional charges:
-            |  #{pool.additionalAmount}
-        li.mb-1
-            strong Payable total:
-            |  #{pool.payableAmount}
-        li.mb-1
-            strong Outstanding payments:
-            |  #{pool.outstandingAmount}
-        li.mb-1
-            strong Assigned to:
-            |  #{pool.assignAll ? 'All participants' : assignments.length}
+    .pool-totals.border.border-secondary-subtle.rounded-3.p-3.bg-black
+        .d-flex.justify-content-between.align-items-start.gap-3
+            .flex-grow-1
+                small.text-secondary.text-uppercase.fw-semibold.mb-1.d-block Full total
+                div.fs-2.fw-bold.text-white #{pool.payableAmount}
+                p.text-secondary.small.mb-0 A summary of everything owed in this pool.
+            .text-end
+                span.badge.bg-info.text-dark #{pool.status}
+        .row.g-2.mt-3
+            .col-sm-6
+                ul.list-unstyled.mb-0.small
+                    li.mb-1
+                        strong Total invoices:
+                        |  #{pool.totalAmount}
+                    li.mb-1
+                        strong Open invoices:
+                        |  #{pool.openAmount}
+                    li.mb-1
+                        strong Additional charges:
+                        |  #{pool.additionalAmount}
+            .col-sm-6
+                ul.list-unstyled.mb-0.small
+                    li.mb-1
+                        strong Payable total:
+                        |  #{pool.payableAmount}
+                    li.mb-1
+                        strong Outstanding payments:
+                        |  #{pool.outstandingAmount}
+                    li.mb-1
+                        strong Assigned to:
+                        |  #{pool.assignAll ? 'All participants' : assignments.length}
 
 //- Assignment form kept separate so both admin tabs and future reuse can pull it in
 mixin poolAssignmentsForm(ev, pool, participants)
     form.pool-assignment(data-api=`/api/event/${ev.id}/invoice-pools/${pool.id}/assignments`)
         label.form-label.text-secondary.mb-1 Update assignment
         .form-check
-            input.form-check-input(type="checkbox" name="assignAll" id=`assign-${pool.id}` checked=!!(pool.assignAll))
+            input.form-check-input.pool-toggle(type="checkbox" name="assignAll" id=`assign-${pool.id}` checked=!!(pool.assignAll))
             label.form-check-label(for=`assign-${pool.id}`) Assign to all participants
         .form-check
-            input.form-check-input(type="checkbox" name="isDefault" id=`default-${pool.id}` checked=!!(pool.isDefault))
+            input.form-check-input.pool-toggle(type="checkbox" name="isDefault" id=`default-${pool.id}` checked=!!(pool.isDefault))
             label.form-check-label(for=`default-${pool.id}`) Default for new participants
-        select.form-select.text-bg-dark(name="registrations" multiple size="4" aria-label="Pool participants" disabled=!!(pool.assignAll || pool.isDefault))
-            each p in participants
-                - const selected = pool.assignments?.some(a => a.registration?.id === p.id)
-                option(value=p.id selected=selected)= `${p.name} (${p.email})`
+        label.form-label.mt-2(for=`assign-list-${pool.id}`) Limit to participants (disabled when default or assign to all)
+        .assignments-list.border.border-secondary-subtle.rounded-3.p-2.bg-black.text-white#`assign-list-${pool.id}`
+            if participants && participants.length
+                each p in participants
+                    - const selected = pool.assignments?.some(a => a.registration?.id === p.id)
+                    .form-check
+                        input.form-check-input(type="checkbox" name="registrations" value=p.id id=`pool-${pool.id}-reg-${p.id}` checked=selected disabled=!!(pool.assignAll || pool.isDefault))
+                        label.form-check-label(for=`pool-${pool.id}-reg-${p.id}`)= `${p.name} (${p.email})`
+            else
+                p.text-secondary.small.mb-0 No participants yet.
         button.btn.btn-outline-light.btn-sm.mt-2(type="submit")
             i.bi.bi-save.me-1
             | Save assignments
@@ -338,7 +370,7 @@ mixin poolAdjustmentSection(ev, pool, participants)
         p.text-secondary.small.mb-2 Add surcharges with notes before closing. These amounts are paid only by the participant or their covering payer.
         +poolSurchargeList(pool, participants)
         +poolSurchargeForm(ev, pool, participants)
-        .mt-3
+        .mt-4
             +takeoverOverview(pool, participants, 'admin')
 
 //- Shares and payment toggles grouped for clarity
@@ -350,56 +382,80 @@ mixin poolShareSection(pool, participants)
 mixin poolManagementSection(ev, pool, participants)
     - const assignedIds = pool.assignAll ? participants.map(p => p.id) : (pool.assignments || []).map(a => a.registration?.id)
     - const takeoverData = (pool.takeovers || []).map(t => ({payerRegistrationId: t.payerRegistrationId, beneficiaryRegistrationId: t.beneficiaryRegistrationId}))
-    .invoice-pool.border-top.border-secondary-subtle.pt-3.mt-3(data-pool=pool.id data-assigned=JSON.stringify(assignedIds) data-takeovers=JSON.stringify(takeoverData))
-        +poolHeader(pool)
-        .row.mt-2
-            .col-md-3
-                +poolStats(pool)
-            .col-md-9
+    .accordion-item.bg-dark.text-white.border-secondary-subtle.invoice-pool(data-pool=pool.id data-assigned=JSON.stringify(assignedIds) data-takeovers=JSON.stringify(takeoverData))
+        h2.accordion-header
+            button.accordion-button.collapsed.text-white(type="button" data-bs-toggle="collapse" data-bs-target=`#pool-${pool.id}-body` aria-expanded="false" aria-controls=`pool-${pool.id}-body`)
+                +poolHeaderSummary(pool)
+        .accordion-collapse.collapse(id=`pool-${pool.id}-body`)
+            .accordion-body
+                .d-flex.justify-content-between.align-items-start.flex-wrap.gap-2.mb-3
+                    +poolHeader(pool)
+                    if pool.status === 'OPEN'
+                        button.btn.btn-sm.btn-warning.pool-close(type="button" data-id=pool.id)
+                            i.bi.bi-x-circle.me-1
+                            | Close pool
+                .row.mt-2
+                    .col-md-4
+                        +poolStats(pool)
+                    .col-md-8
+                        if pool.status === 'OPEN'
+                            +poolAssignmentsForm(ev, pool, participants)
+                        else
+                            +poolShareSection(pool, participants)
                 if pool.status === 'OPEN'
-                    +poolAssignmentsForm(ev, pool, participants)
-                else
-                    +poolShareSection(pool, participants)
-        if pool.status === 'OPEN'
-            +poolAdjustmentSection(ev, pool, participants)
-        +invoiceOverview('admin', {pool: pool, participants: participants, eventId: ev.id})
+                    +poolAdjustmentSection(ev, pool, participants)
+                +invoiceOverview('admin', {pool: pool, participants: participants, eventId: ev.id})
 
 //- Management tab content for the admin dashboard
 mixin invoicePoolManageTab(ev, pools, participants)
     if pools && pools.length
-        each pool in pools
-            +poolManagementSection(ev, pool, participants)
+        .accordion.accordion-dark#invoicePoolAccordion
+            each pool in pools
+                +poolManagementSection(ev, pool, participants)
     else
         p.text-secondary.mb-0 No invoice pools created yet.
 
 //- Pool creation tab content for the admin dashboard
-mixin invoicePoolCreateTab(ev, participants)
-    form#poolCreateForm(data-api=`/api/event/${ev.id}/invoice-pools`)
-        .row.g-3
-            .col-md-4
-                label.form-label(for="poolName") Pool name
-                input#poolName.form-control.text-bg-dark(type="text" name="name" required maxlength="255")
-            .col-md-4
-                label.form-label(for="poolDescription") Description
-                input#poolDescription.form-control.text-bg-dark(type="text" name="description")
-            .col-md-4
-                label.form-label.text-secondary Allocation
-                .form-check
-                    input#assignAllPools.form-check-input(type="checkbox" name="assignAll" checked)
-                    label.form-check-label(for="assignAllPools") Assign to all participants
-                .form-check
-                    input#defaultPool.form-check-input(type="checkbox" name="isDefault")
-                    label.form-check-label(for="defaultPool") Make this the default pool
-                small.text-secondary Default pools automatically include future participants without reopening assignments.
-            .col-12
-                label.form-label(for="poolRegistrations") Limit to participants (disabled when default or assign to all)
-                select#poolRegistrations.form-select.text-bg-dark(name="registrations" multiple size="4")
-                    each p in participants
-                        option(value=p.id)= `${p.name} (${p.email})`
-        .d-flex.justify-content-end.mt-2
-            button.btn.btn-primary(type="submit")
-                i.bi.bi-plus-circle.me-1
-                | Add pool
+mixin invoicePoolCreateModal(ev, participants)
+    .modal.fade#poolCreateModal(tabindex="-1" aria-labelledby="poolCreateLabel" aria-hidden="true")
+        .modal-dialog.modal-lg
+            .modal-content.bg-dark.text-white
+                .modal-header
+                    h5.modal-title#poolCreateLabel Create a new pool
+                    button.btn-close.btn-close-white(type="button" data-bs-dismiss="modal" aria-label="Close")
+                form#poolCreateForm(data-api=`/api/event/${ev.id}/invoice-pools`)
+                    .modal-body
+                        .row.g-3
+                            .col-md-4
+                                label.form-label(for="poolName") Pool name
+                                input#poolName.form-control.text-bg-dark(type="text" name="name" required maxlength="255")
+                            .col-md-4
+                                label.form-label(for="poolDescription") Description
+                                input#poolDescription.form-control.text-bg-dark(type="text" name="description")
+                            .col-md-4
+                                label.form-label.text-secondary Allocation
+                                .form-check
+                                    input#assignAllPools.form-check-input.pool-toggle(type="checkbox" name="assignAll" checked)
+                                    label.form-check-label(for="assignAllPools") Assign to all participants
+                                .form-check
+                                    input#defaultPool.form-check-input.pool-toggle(type="checkbox" name="isDefault")
+                                    label.form-check-label(for="defaultPool") Make this the default pool
+                                small.text-secondary Default pools automatically include future participants without reopening assignments.
+                            .col-12
+                                label.form-label(for="poolRegistrations") Limit to participants (disabled when default or assign to all)
+                                .assignments-list.border.border-secondary-subtle.rounded-3.p-2.bg-black.text-white#poolRegistrations
+                                    if participants && participants.length
+                                        each p in participants
+                                            .form-check
+                                                input.form-check-input(type="checkbox" name="registrations" value=p.id id=`pool-create-reg-${p.id}` disabled checked)
+                                                label.form-check-label(for=`pool-create-reg-${p.id}`)= `${p.name} (${p.email})`
+                                    else
+                                        p.text-secondary.small.mb-0 No participants yet.
+                    .modal-footer
+                        button.btn.btn-secondary(type="button" data-bs-dismiss="modal") Cancel
+                        button.btn.btn-primary(type="submit")
+                            i.bi.bi-plus-circle.me-1
+                            | Add pool
 
 //- Wrapper to tie together the manage and create tabs
 mixin invoiceManagementTabs(ev, data)
@@ -408,17 +464,12 @@ mixin invoiceManagementTabs(ev, data)
             .d-flex.align-items-center.gap-2
                 i.bi.bi-receipt
                 span Invoice pools
-            ul.nav.nav-tabs.border-0
-                li.nav-item
-                    a.nav-link.active(href="#pool-manage" data-bs-toggle="tab" role="tab") Manage
-                li.nav-item
-                    a.nav-link(href="#pool-create" data-bs-toggle="tab" role="tab") Create
+            button.btn.btn-primary.btn-sm(type="button" data-bs-toggle="modal" data-bs-target="#poolCreateModal")
+                i.bi.bi-plus-circle.me-1
+                | Create pool
         .card-body
-            .tab-content
-                .tab-pane.fade.show.active#pool-manage
-                    +invoicePoolManageTab(ev, data.invoicePools, data.participants || [])
-                .tab-pane.fade#pool-create
-                    +invoicePoolCreateTab(ev, data.participants || [])
+            +invoicePoolManageTab(ev, data.invoicePools, data.participants || [])
+    +invoicePoolCreateModal(ev, data.participants || [])
 
 //- Shared takeover modal for admins/participants with a search field
 mixin takeoverModal(id)


### PR DESCRIPTION
## Summary
- Convert admin invoice pools into a collapsed accordion with modal-based pool creation and more prominent totals.
- Replace multi-select assignment controls with checkbox lists, align takeover management visuals, and add scrollable invoice lists.
- Collapse the participant invoice area by default while keeping invoice history and share summaries visible even after pools close.

## Testing
- npm run build:sass


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693223032a7883329c3f2dd58e655169)