### PR TITLE
Refine pool credits and reuse date modal

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,6 +26,8 @@ For general AI agent guidance, see [AGENTS.md](../AGENTS.md).
 2. **Database**: Always create migrations, never use synchronize in production
 3. **Testing**: Use data-driven and keyword-driven approaches (see TESTING.md)
 4. **Security**: Never commit secrets, validate all input, hash passwords
+5. **Following Directions**: Always follow user directions. If you are not sure, make reasonable assumptions. Interpret requirements conservatively.
+6. **Generic approach**: If the user asks you to fix all tests, fix all tests including database and e2e tests. Fix all issues including those that are not influenced or caused by your changes.
 
 ## Testing Approach
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,41 +63,59 @@
         "typescript": "^5.9.2"
       }
     },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.26",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.26.tgz",
+      "integrity": "sha512-UMFbL3EnWH/eTvl21dz9s7Td4wYDMtxz/56zD8sL9IZGYyi48RxmdgPMiyT7R6Vn3rjMTwYZ42bqKa7ex74GEQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.0.4.tgz",
-      "integrity": "sha512-cKjSKvWGmAziQWbCouOsFwb14mp1betm8Y7Fn+yglDMUUu3r9DCbJ9iJbeFDenLMqFbIMC0pQP8K+B8LAxX3OQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.0.tgz",
+      "integrity": "sha512-9xiBAtLn4aNsa4mDnpovJvBn72tNEIACyvlqaNJ+ADemR+yeMJWnBudOi2qGDviJa7SwcDOU/TRh5dnET7qk0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@csstools/css-calc": "^2.1.4",
-        "@csstools/css-color-parser": "^3.0.10",
+        "@csstools/css-color-parser": "^3.1.0",
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
-        "lru-cache": "^11.1.0"
+        "lru-cache": "^11.2.2"
       }
     },
     "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.1.tgz",
-      "integrity": "sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==",
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       }
     },
     "node_modules/@asamuzakjp/dom-selector": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.5.4.tgz",
-      "integrity": "sha512-RNSNk1dnB8lAn+xdjlRoM4CzdVrHlmXZtSXAWs2jyl4PiBRWqTZr9ML5M710qgd9RPTBsVG6P0SLy7dwy0Foig==",
+      "version": "6.7.5",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.5.tgz",
+      "integrity": "sha512-Eks6dY8zau4m4wNRQjRVaKQRTalNcPcBvU1ZQ35w5kKRk1gUeNCkVLsRiATurjASTp3TKM4H10wsI50nx3NZdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/nwsapi": "^2.3.9",
         "bidi-js": "^1.0.3",
         "css-tree": "^3.1.0",
-        "is-potential-custom-element-name": "^1.0.1"
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.2"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@asamuzakjp/nwsapi": {
@@ -106,6 +124,694 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ses": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.943.0.tgz",
+      "integrity": "sha512-E4DGprMHjvuq/CbTfCI39cP0iQwqK7GY5AeiehxovBqzoKwx2xEBFB+RFVlXa3EHLRohEAlhUzXnxGsG0PgyAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.943.0",
+        "@aws-sdk/credential-provider-node": "3.943.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.943.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.943.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-waiter": "^4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.943.0.tgz",
+      "integrity": "sha512-kOTO2B8Ks2qX73CyKY8PAajtf5n39aMe2spoiOF5EkgSzGV7hZ/HONRDyADlyxwfsX39Q2F2SpPUaXzon32IGw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.943.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.943.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.943.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.943.0.tgz",
+      "integrity": "sha512-8CBy2hI9ABF7RBVQuY1bgf/ue+WPmM/hl0adrXFlhnhkaQP0tFY5zhiy1Y+n7V+5f3/ORoHBmCCQmcHDDYJqJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/xml-builder": "3.930.0",
+        "@smithy/core": "^3.18.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.943.0.tgz",
+      "integrity": "sha512-WnS5w9fK9CTuoZRVSIHLOMcI63oODg9qd1vXMYb7QGLGlfwUm4aG3hdu7i9XvYrpkQfE3dzwWLtXF4ZBuL1Tew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.943.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.943.0.tgz",
+      "integrity": "sha512-SA8bUcYDEACdhnhLpZNnWusBpdmj4Vl67Vxp3Zke7SvoWSYbuxa+tiDiC+c92Z4Yq6xNOuLPW912ZPb9/NsSkA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.943.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-stream": "^4.5.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.943.0.tgz",
+      "integrity": "sha512-BcLDb8l4oVW+NkuqXMlO7TnM6lBOWW318ylf4FRED/ply5eaGxkQYqdGvHSqGSN5Rb3vr5Ek0xpzSjeYD7C8Kw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.943.0",
+        "@aws-sdk/credential-provider-env": "3.943.0",
+        "@aws-sdk/credential-provider-http": "3.943.0",
+        "@aws-sdk/credential-provider-login": "3.943.0",
+        "@aws-sdk/credential-provider-process": "3.943.0",
+        "@aws-sdk/credential-provider-sso": "3.943.0",
+        "@aws-sdk/credential-provider-web-identity": "3.943.0",
+        "@aws-sdk/nested-clients": "3.943.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.943.0.tgz",
+      "integrity": "sha512-9iCOVkiRW+evxiJE94RqosCwRrzptAVPhRhGWv4osfYDhjNAvUMyrnZl3T1bjqCoKNcETRKEZIU3dqYHnUkcwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.943.0",
+        "@aws-sdk/nested-clients": "3.943.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.943.0.tgz",
+      "integrity": "sha512-14eddaH/gjCWoLSAELVrFOQNyswUYwWphIt+PdsJ/FqVfP4ay2HsiZVEIYbQtmrKHaoLJhiZKwBQRjcqJDZG0w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.943.0",
+        "@aws-sdk/credential-provider-http": "3.943.0",
+        "@aws-sdk/credential-provider-ini": "3.943.0",
+        "@aws-sdk/credential-provider-process": "3.943.0",
+        "@aws-sdk/credential-provider-sso": "3.943.0",
+        "@aws-sdk/credential-provider-web-identity": "3.943.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.943.0.tgz",
+      "integrity": "sha512-GIY/vUkthL33AdjOJ8r9vOosKf/3X+X7LIiACzGxvZZrtoOiRq0LADppdiKIB48vTL63VvW+eRIOFAxE6UDekw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.943.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.943.0.tgz",
+      "integrity": "sha512-1c5G11syUrru3D9OO6Uk+ul5e2lX1adb+7zQNyluNaLPXP6Dina6Sy6DFGRLu7tM8+M7luYmbS3w63rpYpaL+A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.943.0",
+        "@aws-sdk/core": "3.943.0",
+        "@aws-sdk/token-providers": "3.943.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.943.0.tgz",
+      "integrity": "sha512-VtyGKHxICSb4kKGuaqotxso8JVM8RjCS3UYdIMOxUt9TaFE/CZIfZKtjTr+IJ7M0P7t36wuSUb/jRLyNmGzUUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.943.0",
+        "@aws-sdk/nested-clients": "3.943.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.936.0.tgz",
+      "integrity": "sha512-tAaObaAnsP1XnLGndfkGWFuzrJYuk9W0b/nLvol66t8FZExIAf/WdkT2NNAWOYxljVs++oHnyHBCxIlaHrzSiw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.936.0.tgz",
+      "integrity": "sha512-aPSJ12d3a3Ea5nyEnLbijCaaYJT2QjQ9iW+zGh5QcZYXmOGWbKVyPSxmVOboZQG+c1M8t6d2O7tqrwzIq8L8qw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.936.0.tgz",
+      "integrity": "sha512-l4aGbHpXM45YNgXggIux1HgsCVAvvBoqHPkqLnqMl9QVapfuSTjJHfDYDsx1Xxct6/m7qSMUzanBALhiaGO2fA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@aws/lambda-invoke-store": "^0.2.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.943.0.tgz",
+      "integrity": "sha512-956n4kVEwFNXndXfhSAN5wO+KRgqiWEEY+ECwLvxmmO8uQ0NWOa8l6l65nTtyuiWzMX81c9BvlyNR5EgUeeUvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.943.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@smithy/core": "^3.18.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.943.0.tgz",
+      "integrity": "sha512-anFtB0p2FPuyUnbOULwGmKYqYKSq1M73c9uZ08jR/NCq6Trjq9cuF5TFTeHwjJyPRb4wMf2Qk859oiVfFqnQiw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.943.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.943.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.943.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.936.0.tgz",
+      "integrity": "sha512-wOKhzzWsshXGduxO4pqSiNyL9oUtk4BEvjWm9aaq6Hmfdoydq6v6t0rAGHWPjFwy9z2haovGRi3C8IxdMB4muw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.943.0.tgz",
+      "integrity": "sha512-cRKyIzwfkS+XztXIFPoWORuaxlIswP+a83BJzelX4S1gUZ7FcXB4+lj9Jxjn8SbQhR4TPU3Owbpu+S7pd6IRbQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.943.0",
+        "@aws-sdk/nested-clients": "3.943.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.936.0.tgz",
+      "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
+      "integrity": "sha512-0Zx3Ntdpu+z9Wlm7JKUBOzS9EunwKAb4KdGUQQxDqh5Lc3ta5uBoub+FgmVuzwnmBu9U1Os8UuwVTH0Lgu+P5w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-endpoints": "^3.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.893.0.tgz",
+      "integrity": "sha512-T89pFfgat6c8nMmpI8eKjBcDcgJq36+m9oiXbcUzeU55MP9ZuGgBomGjGnHaEyF36jenW9gmg3NfZDm0AO2XPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.936.0.tgz",
+      "integrity": "sha512-eZ/XF6NxMtu+iCma58GRNRxSq4lHo6zHQLOZRIeL/ghqYJirqHdenMOwrzPettj60KWlv827RVebP9oNVrwZbw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.943.0.tgz",
+      "integrity": "sha512-gn+ILprVRrgAgTIBk2TDsJLRClzIOdStQFeFTcN0qpL8Z4GBCqMFhw7O7X+MM55Stt5s4jAauQ/VvoqmCADnQg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.943.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.930.0.tgz",
+      "integrity": "sha512-YIfkD17GocxdmlUVc3ia52QhcWuRIUJonbF8A2CYfcWNV3HzvAqpcPeC0bYUhkK+8e8YO1ARnLKZQE0TlwzorA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.2.tgz",
+      "integrity": "sha512-C0NBLsIqzDIae8HFw9YIrIBsbc0xTiOtt7fAukGPnqQ/+zZNaq+4jhuccltK0QuWHBnNm/a6kLIRA6GFiM10eg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -123,9 +829,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
-      "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
+      "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -133,22 +839,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
-      "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
+      "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.3",
+        "@babel/generator": "^7.28.5",
         "@babel/helper-compilation-targets": "^7.27.2",
         "@babel/helper-module-transforms": "^7.28.3",
         "@babel/helpers": "^7.28.4",
-        "@babel/parser": "^7.28.4",
+        "@babel/parser": "^7.28.5",
         "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.4",
-        "@babel/types": "^7.28.4",
+        "@babel/traverse": "^7.28.5",
+        "@babel/types": "^7.28.5",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -165,31 +870,20 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
-      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
+      "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.3",
-        "@babel/types": "^7.28.2",
+        "@babel/parser": "^7.28.5",
+        "@babel/types": "^7.28.5",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/generator/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.30",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
-      "integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
@@ -207,16 +901,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
       }
     },
     "node_modules/@babel/helper-globals": {
@@ -282,9 +966,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -316,13 +1000,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
-      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
+      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.4"
+        "@babel/types": "^7.28.5"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -586,18 +1270,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
-      "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
+      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.3",
+        "@babel/generator": "^7.28.5",
         "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.4",
+        "@babel/parser": "^7.28.5",
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4",
+        "@babel/types": "^7.28.5",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -605,14 +1289,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
-      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
+      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-validator-identifier": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -636,6 +1320,17 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -726,7 +1421,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -735,9 +1429,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.14.tgz",
-      "integrity": "sha512-zSlIxa20WvMojjpCSy8WrNpcZ61RqfTfX3XTaOeVlGJrt/8HF3YbzgFZa01yTbT4GWQLwfTcC3EB8i3XnB647Q==",
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.20.tgz",
+      "integrity": "sha512-8BHsjXfSciZxjmHQOuVdW2b8WLUPts9a+mfL13/PzEviufUEW2xnvQuOlKs9dRBHgRqJ53SF/DUoK9+MZk72oQ==",
       "dev": true,
       "funding": [
         {
@@ -752,9 +1446,6 @@
       "license": "MIT-0",
       "engines": {
         "node": ">=18"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4"
       }
     },
     "node_modules/@csstools/css-tokenizer": {
@@ -773,15 +1464,14 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
-      "integrity": "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.7.1.tgz",
+      "integrity": "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -791,9 +1481,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
-      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
+      "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -813,9 +1503,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.6.tgz",
-      "integrity": "sha512-ShbM/3XxwuxjFiuVBHA+d3j5dyac0aEVVq1oluIDf71hUw0aRF59dV/efUsIwFnR6m8JNM2FjZOzmaZ8yG61kw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
       "cpu": [
         "ppc64"
       ],
@@ -830,9 +1520,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.6.tgz",
-      "integrity": "sha512-S8ToEOVfg++AU/bHwdksHNnyLyVM+eMVAOf6yRKFitnwnbwwPNqKr3srzFRe7nzV69RQKb5DgchIX5pt3L53xg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
       "cpu": [
         "arm"
       ],
@@ -847,9 +1537,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.6.tgz",
-      "integrity": "sha512-hd5zdUarsK6strW+3Wxi5qWws+rJhCCbMiC9QZyzoxfk5uHRIE8T287giQxzVpEvCwuJ9Qjg6bEjcRJcgfLqoA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
       "cpu": [
         "arm64"
       ],
@@ -864,9 +1554,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.6.tgz",
-      "integrity": "sha512-0Z7KpHSr3VBIO9A/1wcT3NTy7EB4oNC4upJ5ye3R7taCc2GUdeynSLArnon5G8scPwaU866d3H4BCrE5xLW25A==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
       "cpu": [
         "x64"
       ],
@@ -881,9 +1571,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.6.tgz",
-      "integrity": "sha512-FFCssz3XBavjxcFxKsGy2DYK5VSvJqa6y5HXljKzhRZ87LvEi13brPrf/wdyl/BbpbMKJNOr1Sd0jtW4Ge1pAA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
       "cpu": [
         "arm64"
       ],
@@ -898,9 +1588,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.6.tgz",
-      "integrity": "sha512-GfXs5kry/TkGM2vKqK2oyiLFygJRqKVhawu3+DOCk7OxLy/6jYkWXhlHwOoTb0WqGnWGAS7sooxbZowy+pK9Yg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
       "cpu": [
         "x64"
       ],
@@ -915,9 +1605,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.6.tgz",
-      "integrity": "sha512-aoLF2c3OvDn2XDTRvn8hN6DRzVVpDlj2B/F66clWd/FHLiHaG3aVZjxQX2DYphA5y/evbdGvC6Us13tvyt4pWg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
       "cpu": [
         "arm64"
       ],
@@ -932,9 +1622,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.6.tgz",
-      "integrity": "sha512-2SkqTjTSo2dYi/jzFbU9Plt1vk0+nNg8YC8rOXXea+iA3hfNJWebKYPs3xnOUf9+ZWhKAaxnQNUf2X9LOpeiMQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
       "cpu": [
         "x64"
       ],
@@ -949,9 +1639,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.6.tgz",
-      "integrity": "sha512-SZHQlzvqv4Du5PrKE2faN0qlbsaW/3QQfUUc6yO2EjFcA83xnwm91UbEEVx4ApZ9Z5oG8Bxz4qPE+HFwtVcfyw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
       "cpu": [
         "arm"
       ],
@@ -966,9 +1656,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.6.tgz",
-      "integrity": "sha512-b967hU0gqKd9Drsh/UuAm21Khpoh6mPBSgz8mKRq4P5mVK8bpA+hQzmm/ZwGVULSNBzKdZPQBRT3+WuVavcWsQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
       "cpu": [
         "arm64"
       ],
@@ -983,9 +1673,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.6.tgz",
-      "integrity": "sha512-aHWdQ2AAltRkLPOsKdi3xv0mZ8fUGPdlKEjIEhxCPm5yKEThcUjHpWB1idN74lfXGnZ5SULQSgtr5Qos5B0bPw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
       "cpu": [
         "ia32"
       ],
@@ -1000,9 +1690,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.6.tgz",
-      "integrity": "sha512-VgKCsHdXRSQ7E1+QXGdRPlQ/e08bN6WMQb27/TMfV+vPjjTImuT9PmLXupRlC90S1JeNNW5lzkAEO/McKeJ2yg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
       "cpu": [
         "loong64"
       ],
@@ -1017,9 +1707,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.6.tgz",
-      "integrity": "sha512-WViNlpivRKT9/py3kCmkHnn44GkGXVdXfdc4drNmRl15zVQ2+D2uFwdlGh6IuK5AAnGTo2qPB1Djppj+t78rzw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
       "cpu": [
         "mips64el"
       ],
@@ -1034,9 +1724,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.6.tgz",
-      "integrity": "sha512-wyYKZ9NTdmAMb5730I38lBqVu6cKl4ZfYXIs31Baf8aoOtB4xSGi3THmDYt4BTFHk7/EcVixkOV2uZfwU3Q2Jw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
       "cpu": [
         "ppc64"
       ],
@@ -1051,9 +1741,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.6.tgz",
-      "integrity": "sha512-KZh7bAGGcrinEj4qzilJ4hqTY3Dg2U82c8bv+e1xqNqZCrCyc+TL9AUEn5WGKDzm3CfC5RODE/qc96OcbIe33w==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
       "cpu": [
         "riscv64"
       ],
@@ -1068,9 +1758,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.6.tgz",
-      "integrity": "sha512-9N1LsTwAuE9oj6lHMyyAM+ucxGiVnEqUdp4v7IaMmrwb06ZTEVCIs3oPPplVsnjPfyjmxwHxHMF8b6vzUVAUGw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
       "cpu": [
         "s390x"
       ],
@@ -1085,9 +1775,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.6.tgz",
-      "integrity": "sha512-A6bJB41b4lKFWRKNrWoP2LHsjVzNiaurf7wyj/XtFNTsnPuxwEBWHLty+ZE0dWBKuSK1fvKgrKaNjBS7qbFKig==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
       "cpu": [
         "x64"
       ],
@@ -1102,9 +1792,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.6.tgz",
-      "integrity": "sha512-IjA+DcwoVpjEvyxZddDqBY+uJ2Snc6duLpjmkXm/v4xuS3H+3FkLZlDm9ZsAbF9rsfP3zeA0/ArNDORZgrxR/Q==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
       "cpu": [
         "arm64"
       ],
@@ -1119,9 +1809,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.6.tgz",
-      "integrity": "sha512-dUXuZr5WenIDlMHdMkvDc1FAu4xdWixTCRgP7RQLBOkkGgwuuzaGSYcOpW4jFxzpzL1ejb8yF620UxAqnBrR9g==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
       "cpu": [
         "x64"
       ],
@@ -1136,9 +1826,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.6.tgz",
-      "integrity": "sha512-l8ZCvXP0tbTJ3iaqdNf3pjaOSd5ex/e6/omLIQCVBLmHTlfXW3zAxQ4fnDmPLOB1x9xrcSi/xtCWFwCZRIaEwg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
       "cpu": [
         "arm64"
       ],
@@ -1153,9 +1843,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.6.tgz",
-      "integrity": "sha512-hKrmDa0aOFOr71KQ/19JC7az1P0GWtCN1t2ahYAf4O007DHZt/dW8ym5+CUdJhQ/qkZmI1HAF8KkJbEFtCL7gw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
       "cpu": [
         "x64"
       ],
@@ -1170,9 +1860,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.6.tgz",
-      "integrity": "sha512-+SqBcAWoB1fYKmpWoQP4pGtx+pUUC//RNYhFdbcSA16617cchuryuhOCRpPsjCblKukAckWsV+aQ3UKT/RMPcA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
       "cpu": [
         "arm64"
       ],
@@ -1187,9 +1877,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.6.tgz",
-      "integrity": "sha512-dyCGxv1/Br7MiSC42qinGL8KkG4kX0pEsdb0+TKhmJZgCUDBGmyo1/ArCjNGiOLiIAgdbWgmWgib4HoCi5t7kA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
       "cpu": [
         "x64"
       ],
@@ -1204,9 +1894,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.6.tgz",
-      "integrity": "sha512-42QOgcZeZOvXfsCBJF5Afw73t4veOId//XD3i+/9gSkhSV6Gk3VPlWncctI+JcOyERv85FUo7RxuxGy+z8A43Q==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
       "cpu": [
         "arm64"
       ],
@@ -1221,9 +1911,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.6.tgz",
-      "integrity": "sha512-4AWhgXmDuYN7rJI6ORB+uU9DHLq/erBbuMoAuB4VWJTu5KtCgcKYPynF0YI1VkBNuEfjNlLrFr9KZPJzrtLkrQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
       "cpu": [
         "ia32"
       ],
@@ -1238,9 +1928,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.6.tgz",
-      "integrity": "sha512-NgJPHHbEpLQgDH2MjQu90pzW/5vvXIZ7KOnPyNBm92A6WgZ/7b6fJyUBjoumLqeOQQGqY2QjQxRo97ah4Sj0cA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
       "cpu": [
         "x64"
       ],
@@ -1337,17 +2027,17 @@
       }
     },
     "node_modules/@jest/console": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.1.2.tgz",
-      "integrity": "sha512-BGMAxj8VRmoD0MoA/jo9alMXSRoqW8KPeqOfEo1ncxnRLatTBCpRoOwlwlEMdudp68Q6WSGwYrrLtTGOh8fLzw==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.2.0.tgz",
+      "integrity": "sha512-+O1ifRjkvYIkBqASKWgLxrpEhQAAE7hY77ALLUufSk5717KfOShg6IbqLmdsLMPdUiFvA2kTs0R7YZy+l0IzZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.0.5",
+        "@jest/types": "30.2.0",
         "@types/node": "*",
         "chalk": "^4.1.2",
-        "jest-message-util": "30.1.0",
-        "jest-util": "30.0.5",
+        "jest-message-util": "30.2.0",
+        "jest-util": "30.2.0",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -1355,39 +2045,39 @@
       }
     },
     "node_modules/@jest/core": {
-      "version": "30.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.1.3.tgz",
-      "integrity": "sha512-LIQz7NEDDO1+eyOA2ZmkiAyYvZuo6s1UxD/e2IHldR6D7UYogVq3arTmli07MkENLq6/3JEQjp0mA8rrHHJ8KQ==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.2.0.tgz",
+      "integrity": "sha512-03W6IhuhjqTlpzh/ojut/pDB2LPRygyWX8ExpgHtQA8H/3K7+1vKmcINx5UzeOX1se6YEsBsOHQ1CRzf3fOwTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.1.2",
+        "@jest/console": "30.2.0",
         "@jest/pattern": "30.0.1",
-        "@jest/reporters": "30.1.3",
-        "@jest/test-result": "30.1.3",
-        "@jest/transform": "30.1.2",
-        "@jest/types": "30.0.5",
+        "@jest/reporters": "30.2.0",
+        "@jest/test-result": "30.2.0",
+        "@jest/transform": "30.2.0",
+        "@jest/types": "30.2.0",
         "@types/node": "*",
         "ansi-escapes": "^4.3.2",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
         "exit-x": "^0.2.2",
         "graceful-fs": "^4.2.11",
-        "jest-changed-files": "30.0.5",
-        "jest-config": "30.1.3",
-        "jest-haste-map": "30.1.0",
-        "jest-message-util": "30.1.0",
+        "jest-changed-files": "30.2.0",
+        "jest-config": "30.2.0",
+        "jest-haste-map": "30.2.0",
+        "jest-message-util": "30.2.0",
         "jest-regex-util": "30.0.1",
-        "jest-resolve": "30.1.3",
-        "jest-resolve-dependencies": "30.1.3",
-        "jest-runner": "30.1.3",
-        "jest-runtime": "30.1.3",
-        "jest-snapshot": "30.1.2",
-        "jest-util": "30.0.5",
-        "jest-validate": "30.1.0",
-        "jest-watcher": "30.1.3",
+        "jest-resolve": "30.2.0",
+        "jest-resolve-dependencies": "30.2.0",
+        "jest-runner": "30.2.0",
+        "jest-runtime": "30.2.0",
+        "jest-snapshot": "30.2.0",
+        "jest-util": "30.2.0",
+        "jest-validate": "30.2.0",
+        "jest-watcher": "30.2.0",
         "micromatch": "^4.0.8",
-        "pretty-format": "30.0.5",
+        "pretty-format": "30.2.0",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -1413,39 +2103,39 @@
       }
     },
     "node_modules/@jest/environment": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.1.2.tgz",
-      "integrity": "sha512-N8t1Ytw4/mr9uN28OnVf0SYE2dGhaIxOVYcwsf9IInBKjvofAjbFRvedvBBlyTYk2knbJTiEjEJ2PyyDIBnd9w==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.2.0.tgz",
+      "integrity": "sha512-/QPTL7OBJQ5ac09UDRa3EQes4gt1FTEG/8jZ/4v5IVzx+Cv7dLxlVIvfvSVRiiX2drWyXeBjkMSR8hvOWSog5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/fake-timers": "30.1.2",
-        "@jest/types": "30.0.5",
+        "@jest/fake-timers": "30.2.0",
+        "@jest/types": "30.2.0",
         "@types/node": "*",
-        "jest-mock": "30.0.5"
+        "jest-mock": "30.2.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/expect": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.1.2.tgz",
-      "integrity": "sha512-tyaIExOwQRCxPCGNC05lIjWJztDwk2gPDNSDGg1zitXJJ8dC3++G/CRjE5mb2wQsf89+lsgAgqxxNpDLiCViTA==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.2.0.tgz",
+      "integrity": "sha512-V9yxQK5erfzx99Sf+7LbhBwNWEZ9eZay8qQ9+JSC0TrMR1pMDHLMY+BnVPacWU6Jamrh252/IKo4F1Xn/zfiqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "expect": "30.1.2",
-        "jest-snapshot": "30.1.2"
+        "expect": "30.2.0",
+        "jest-snapshot": "30.2.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/expect-utils": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.1.2.tgz",
-      "integrity": "sha512-HXy1qT/bfdjCv7iC336ExbqqYtZvljrV8odNdso7dWK9bSeHtLlvwWWC3YSybSPL03Gg5rug6WLCZAZFH72m0A==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.2.0.tgz",
+      "integrity": "sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1456,18 +2146,18 @@
       }
     },
     "node_modules/@jest/fake-timers": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.1.2.tgz",
-      "integrity": "sha512-Beljfv9AYkr9K+ETX9tvV61rJTY706BhBUtiaepQHeEGfe0DbpvUA5Z3fomwc5Xkhns6NWrcFDZn+72fLieUnA==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.2.0.tgz",
+      "integrity": "sha512-HI3tRLjRxAbBy0VO8dqqm7Hb2mIa8d5bg/NJkyQcOk7V118ObQML8RC5luTF/Zsg4474a+gDvhce7eTnP4GhYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.0.5",
+        "@jest/types": "30.2.0",
         "@sinonjs/fake-timers": "^13.0.0",
         "@types/node": "*",
-        "jest-message-util": "30.1.0",
-        "jest-mock": "30.0.5",
-        "jest-util": "30.0.5"
+        "jest-message-util": "30.2.0",
+        "jest-mock": "30.2.0",
+        "jest-util": "30.2.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -1484,16 +2174,16 @@
       }
     },
     "node_modules/@jest/globals": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.1.2.tgz",
-      "integrity": "sha512-teNTPZ8yZe3ahbYnvnVRDeOjr+3pu2uiAtNtrEsiMjVPPj+cXd5E/fr8BL7v/T7F31vYdEHrI5cC/2OoO/vM9A==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.2.0.tgz",
+      "integrity": "sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.1.2",
-        "@jest/expect": "30.1.2",
-        "@jest/types": "30.0.5",
-        "jest-mock": "30.0.5"
+        "@jest/environment": "30.2.0",
+        "@jest/expect": "30.2.0",
+        "@jest/types": "30.2.0",
+        "jest-mock": "30.2.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -1514,17 +2204,17 @@
       }
     },
     "node_modules/@jest/reporters": {
-      "version": "30.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.1.3.tgz",
-      "integrity": "sha512-VWEQmJWfXMOrzdFEOyGjUEOuVXllgZsoPtEHZzfdNz18RmzJ5nlR6kp8hDdY8dDS1yGOXAY7DHT+AOHIPSBV0w==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.2.0.tgz",
+      "integrity": "sha512-DRyW6baWPqKMa9CzeiBjHwjd8XeAyco2Vt8XbcLFjiwCOEKOvy82GJ8QQnJE9ofsxCMPjH4MfH8fCWIHHDKpAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "30.1.2",
-        "@jest/test-result": "30.1.3",
-        "@jest/transform": "30.1.2",
-        "@jest/types": "30.0.5",
+        "@jest/console": "30.2.0",
+        "@jest/test-result": "30.2.0",
+        "@jest/transform": "30.2.0",
+        "@jest/types": "30.2.0",
         "@jridgewell/trace-mapping": "^0.3.25",
         "@types/node": "*",
         "chalk": "^4.1.2",
@@ -1537,9 +2227,9 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^5.0.0",
         "istanbul-reports": "^3.1.3",
-        "jest-message-util": "30.1.0",
-        "jest-util": "30.0.5",
-        "jest-worker": "30.1.0",
+        "jest-message-util": "30.2.0",
+        "jest-util": "30.2.0",
+        "jest-worker": "30.2.0",
         "slash": "^3.0.0",
         "string-length": "^4.0.2",
         "v8-to-istanbul": "^9.0.1"
@@ -1556,15 +2246,81 @@
         }
       }
     },
-    "node_modules/@jest/reporters/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.30",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
-      "integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
+    "node_modules/@jest/reporters/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dev": true,
-      "license": "MIT",
+      "license": "ISC",
       "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@jest/reporters/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@jest/schemas": {
@@ -1581,13 +2337,13 @@
       }
     },
     "node_modules/@jest/snapshot-utils": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.1.2.tgz",
-      "integrity": "sha512-vHoMTpimcPSR7OxS2S0V1Cpg8eKDRxucHjoWl5u4RQcnxqQrV3avETiFpl8etn4dqxEGarBeHbIBety/f8mLXw==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.2.0.tgz",
+      "integrity": "sha512-0aVxM3RH6DaiLcjj/b0KrIBZhSX1373Xci4l3cW5xiUWPctZ59zQ7jj4rqcJQ/Z8JuN/4wX3FpJSa3RssVvCug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.0.5",
+        "@jest/types": "30.2.0",
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
         "natural-compare": "^1.4.0"
@@ -1611,26 +2367,15 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/@jest/source-map/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.30",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
-      "integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
     "node_modules/@jest/test-result": {
-      "version": "30.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.1.3.tgz",
-      "integrity": "sha512-P9IV8T24D43cNRANPPokn7tZh0FAFnYS2HIfi5vK18CjRkTDR9Y3e1BoEcAJnl4ghZZF4Ecda4M/k41QkvurEQ==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.2.0.tgz",
+      "integrity": "sha512-RF+Z+0CCHkARz5HT9mcQCBulb1wgCP3FBvl9VFokMX27acKphwyQsNuWH3c+ojd1LeWBLoTYoxF0zm6S/66mjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.1.2",
-        "@jest/types": "30.0.5",
+        "@jest/console": "30.2.0",
+        "@jest/types": "30.2.0",
         "@types/istanbul-lib-coverage": "^2.0.6",
         "collect-v8-coverage": "^1.0.2"
       },
@@ -1639,15 +2384,15 @@
       }
     },
     "node_modules/@jest/test-sequencer": {
-      "version": "30.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.1.3.tgz",
-      "integrity": "sha512-82J+hzC0qeQIiiZDThh+YUadvshdBswi5nuyXlEmXzrhw5ZQSRHeQ5LpVMD/xc8B3wPePvs6VMzHnntxL+4E3w==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.2.0.tgz",
+      "integrity": "sha512-wXKgU/lk8fKXMu/l5Hog1R61bL4q5GCdT6OJvdAFz1P+QrpoFuLU68eoKuVc4RbrTtNnTL5FByhWdLgOPSph+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/test-result": "30.1.3",
+        "@jest/test-result": "30.2.0",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.1.0",
+        "jest-haste-map": "30.2.0",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -1655,23 +2400,23 @@
       }
     },
     "node_modules/@jest/transform": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.1.2.tgz",
-      "integrity": "sha512-UYYFGifSgfjujf1Cbd3iU/IQoSd6uwsj8XHj5DSDf5ERDcWMdJOPTkHWXj4U+Z/uMagyOQZ6Vne8C4nRIrCxqA==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.2.0.tgz",
+      "integrity": "sha512-XsauDV82o5qXbhalKxD7p4TZYYdwcaEXC77PPD2HixEFF+6YGppjrAAQurTl2ECWcEomHBMMNS9AH3kcCFx8jA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.27.4",
-        "@jest/types": "30.0.5",
+        "@jest/types": "30.2.0",
         "@jridgewell/trace-mapping": "^0.3.25",
-        "babel-plugin-istanbul": "^7.0.0",
+        "babel-plugin-istanbul": "^7.0.1",
         "chalk": "^4.1.2",
         "convert-source-map": "^2.0.0",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.1.0",
+        "jest-haste-map": "30.2.0",
         "jest-regex-util": "30.0.1",
-        "jest-util": "30.0.5",
+        "jest-util": "30.2.0",
         "micromatch": "^4.0.8",
         "pirates": "^4.0.7",
         "slash": "^3.0.0",
@@ -1681,21 +2426,10 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/@jest/transform/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.30",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
-      "integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
     "node_modules/@jest/types": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.0.5.tgz",
-      "integrity": "sha512-aREYa3aku9SSnea4aX6bhKn4bgv3AXkgijoQgbYV3yvbiGt6z+MQ85+6mIhx9DsKW2BuB/cLR/A+tcMThx+KLQ==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.2.0.tgz",
+      "integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1722,17 +2456,6 @@
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
-    "node_modules/@jridgewell/gen-mapping/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.30",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
-      "integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
@@ -1742,17 +2465,6 @@
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "node_modules/@jridgewell/remapping/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.30",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
-      "integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -1766,21 +2478,21 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "devOptional": true,
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -1810,9 +2522,9 @@
       }
     },
     "node_modules/@paralleldrive/cuid2": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
-      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2227,6 +2939,641 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@smithy/abort-controller": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.5.tgz",
+      "integrity": "sha512-j7HwVkBw68YW8UmFRcjZOmssE77Rvk0GWAIN1oFBhsaovQmZWYCIcGa9/pwRB0ExI8Sk9MWNALTjftjHZea7VA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.3.tgz",
+      "integrity": "sha512-ezHLe1tKLUxDJo2LHtDuEDyWXolw8WGOR92qb4bQdWq/zKenO5BvctZGrVJBK08zjezSk7bmbKFOXIVyChvDLw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.18.7",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.18.7.tgz",
+      "integrity": "sha512-axG9MvKhMWOhFbvf5y2DuyTxQueO0dkedY9QC3mAfndLosRI/9LJv8WaL0mw7ubNhsO4IuXX9/9dYGPFvHrqlw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.5.tgz",
+      "integrity": "sha512-BZwotjoZWn9+36nimwm/OLIcVe+KYRwzMjfhd4QT7QxPm9WY0HiOV8t/Wlh+HVUif0SBVV7ksq8//hPaBC/okQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.6.tgz",
+      "integrity": "sha512-3+RG3EA6BBJ/ofZUeTFJA7mHfSYrZtQIrDP9dI8Lf7X6Jbos2jptuLrAAteDiFVrmbEmLSuRG/bUKzfAXk7dhg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/querystring-builder": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.5.tgz",
+      "integrity": "sha512-DpYX914YOfA3UDT9CN1BM787PcHfWRBB43fFGCYrZFUH0Jv+5t8yYl+Pd5PW4+QzoGEDvn5d5QIO4j2HyYZQSA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.5.tgz",
+      "integrity": "sha512-2L2erASEro1WC5nV+plwIMxrTXpvpfzl4e+Nre6vBVRR2HKeGGcvpJyyL3/PpiSg+cJG2KpTmZmq934Olb6e5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
+      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.5.tgz",
+      "integrity": "sha512-Y/RabVa5vbl5FuHYV2vUCwvh/dqzrEY/K2yWPSqvhFUwIY0atLqO4TienjBXakoy4zrKAMCZwg+YEqmH7jaN7A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.14.tgz",
+      "integrity": "sha512-v0q4uTKgBM8dsqGjqsabZQyH85nFaTnFcgpWU1uydKFsdyyMzfvOkNum9G7VK+dOP01vUnoZxIeRiJ6uD0kjIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.18.7",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.4.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.14.tgz",
+      "integrity": "sha512-Z2DG8Ej7FyWG1UA+7HceINtSLzswUgs2np3sZX0YBBxCt+CXG4QUxv88ZDS3+2/1ldW7LqtSY1UO/6VQ1pND8Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/service-error-classification": "^4.2.5",
+        "@smithy/smithy-client": "^4.9.10",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.6.tgz",
+      "integrity": "sha512-VkLoE/z7e2g8pirwisLz8XJWedUSY8my/qrp81VmAdyrhi94T+riBfwP+AOEEFR9rFTSonC/5D2eWNmFabHyGQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.5.tgz",
+      "integrity": "sha512-bYrutc+neOyWxtZdbB2USbQttZN0mXaOyYLIsaTbJhFsfpXyGWUxJpEuO1rJ8IIJm2qH4+xJT0mxUSsEDTYwdQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.5.tgz",
+      "integrity": "sha512-UTurh1C4qkVCtqggI36DGbLB2Kv8UlcFdMXDcWMbqVY2uRg0XmT9Pb4Vj6oSQ34eizO1fvR0RnFV4Axw4IrrAg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.5.tgz",
+      "integrity": "sha512-CMnzM9R2WqlqXQGtIlsHMEZfXKJVTIrqCNoSd/QpAyp+Dw0a1Vps13l6ma1fH8g7zSPNsA59B/kWgeylFuA/lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/querystring-builder": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.5.tgz",
+      "integrity": "sha512-8iLN1XSE1rl4MuxvQ+5OSk/Zb5El7NJZ1td6Tn+8dQQHIjp59Lwl6bd0+nzw6SKm2wSSriH2v/I9LPzUic7EOg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.5.tgz",
+      "integrity": "sha512-RlaL+sA0LNMp03bf7XPbFmT5gN+w3besXSWMkA8rcmxLSVfiEXElQi4O2IWwPfxzcHkxqrwBFMbngB8yx/RvaQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.5.tgz",
+      "integrity": "sha512-y98otMI1saoajeik2kLfGyRp11e5U/iJYH/wLCh3aTV/XutbGT9nziKGkgCaMD1ghK7p6htHMm6b6scl9JRUWg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.5.tgz",
+      "integrity": "sha512-031WCTdPYgiQRYNPXznHXof2YM0GwL6SeaSyTH/P72M1Vz73TvCNH2Nq8Iu2IEPq9QP2yx0/nrw5YmSeAi/AjQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.5.tgz",
+      "integrity": "sha512-8fEvK+WPE3wUAcDvqDQG1Vk3ANLR8Px979te96m84CbKAjBVf25rPYSzb4xU4hlTyho7VhOGnh5i62D/JVF0JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.0.tgz",
+      "integrity": "sha512-5WmZ5+kJgJDjwXXIzr1vDTG+RhF9wzSODQBfkrQ2VVkYALKGvZX1lgVSxEkgicSAFnFhPj5rudJV0zoinqS0bA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.5.tgz",
+      "integrity": "sha512-xSUfMu1FT7ccfSXkoLl/QRQBi2rOvi3tiBZU2Tdy3I6cgvZ6SEi9QNey+lqps/sJRnogIS+lq+B1gxxbra2a/w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.9.10",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.10.tgz",
+      "integrity": "sha512-Jaoz4Jw1QYHc1EFww/E6gVtNjhoDU+gwRKqXP6C3LKYqqH2UQhP8tMP3+t/ePrhaze7fhLE8vS2q6vVxBANFTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.18.7",
+        "@smithy/middleware-endpoint": "^4.3.14",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-stream": "^4.5.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.9.0.tgz",
+      "integrity": "sha512-MvUbdnXDTwykR8cB1WZvNNwqoWVaTRA0RLlLmf/cIFNMM2cKWz01X4Ly6SMC4Kks30r8tT3Cty0jmeWfiuyHTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.5.tgz",
+      "integrity": "sha512-VaxMGsilqFnK1CeBX+LXnSuaMx4sTL/6znSZh2829txWieazdVxr54HmiyTsIbpOTLcf5nYpq9lpzmwRdxj6rQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
+      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
+      "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
+      "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
+      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
+      "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.13",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.13.tgz",
+      "integrity": "sha512-hlVLdAGrVfyNei+pKIgqDTxfu/ZI2NSyqj4IDxKd5bIsIqwR/dSlkxlPaYxFiIaDVrBy0he8orsFy+Cz119XvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/smithy-client": "^4.9.10",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.16",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.16.tgz",
+      "integrity": "sha512-F1t22IUiJLHrxW9W1CQ6B9PN+skZ9cqSuzB18Eh06HrJPbjsyZ7ZHecAKw80DQtyGTRcVfeukKaCRYebFwclbg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/smithy-client": "^4.9.10",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.5.tgz",
+      "integrity": "sha512-3O63AAWu2cSNQZp+ayl9I3NapW1p1rR5mlVHcF6hAB1dPZUQFfRPYtplWX/3xrzWthPGj5FqB12taJJCfH6s8A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
+      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.5.tgz",
+      "integrity": "sha512-6Y3+rvBF7+PZOc40ybeZMcGln6xJGVeY60E7jy9Mv5iKpMJpHgRE6dKy9ScsVxvfAYuEX4Q9a65DQX90KaQ3bA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.5.tgz",
+      "integrity": "sha512-GBj3+EZBbN4NAqJ/7pAhsXdfzdlznOh8PydUijy6FpNIMnHPSMO2/rP4HKu+UFeikJxShERk528oy7GT79YiJg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.6.tgz",
+      "integrity": "sha512-qWw/UM59TiaFrPevefOZ8CNBKbYEP6wBAIlLqxn3VAIo9rgnTNc4ASbVrqDmhuwI87usnjhdQrxodzAGFFzbRQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
+      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
+      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.5.tgz",
+      "integrity": "sha512-Dbun99A3InifQdIrsXZ+QLcC0PGBPAdrl4cj1mTgJvyc9N2zf7QSxg8TBkzsCmGJdE3TLbO9ycwpY0EkWahQ/g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
+      "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@sqltools/formatter": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@sqltools/formatter/-/formatter-1.2.5.tgz",
@@ -2234,9 +3581,9 @@
       "license": "MIT"
     },
     "node_modules/@tsconfig/node10": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
-      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -2262,9 +3609,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
-      "integrity": "sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2344,9 +3691,9 @@
       }
     },
     "node_modules/@types/cookie-parser": {
-      "version": "1.4.9",
-      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.9.tgz",
-      "integrity": "sha512-tGZiZ2Gtc4m3wIdLkZ8mkj1T6CEHb35+VApbL2T14Dew8HA7c+04dmKqsKRNC+8RJPm16JEK0tFSwdZqubfc4g==",
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.10.tgz",
+      "integrity": "sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -2367,15 +3714,14 @@
       "license": "MIT"
     },
     "node_modules/@types/express": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.3.tgz",
-      "integrity": "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
-        "@types/serve-static": "*"
+        "@types/serve-static": "^2"
       }
     },
     "node_modules/@types/express-flash": {
@@ -2389,9 +3735,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.7.tgz",
-      "integrity": "sha512-R+33OsgWw7rOhD1emjU7dzCDHucJrgJXMA5PYCzJxVil0dsyx5iBEPHqpPfiKNJQb7lZ1vxwoLR4Z87bBUpeGQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.0.tgz",
+      "integrity": "sha512-jnHMsrd0Mwa9Cf4IdOzbz543y4XJepXrbia2T4b6+spXC2We3t1y6K44D3mR8XMFSXMCf3/l7rCgddfx7UNVBA==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -2482,12 +3828,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/mime": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "license": "MIT"
-    },
     "node_modules/@types/morgan": {
       "version": "1.9.10",
       "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.10.tgz",
@@ -2508,22 +3848,22 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.0.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.14.tgz",
-      "integrity": "sha512-4zXMWD91vBLGRtHK3YbIoFMia+1nqEz72coM42C5ETjnNCa/heoj7NT1G67iAfOqMmcfhuCZ4uNpyz8EjlAejw==",
+      "version": "24.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
+      "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "undici-types": "~7.8.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/nodemailer": {
-      "version": "6.4.17",
-      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.17.tgz",
-      "integrity": "sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww==",
+      "version": "6.4.21",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.21.tgz",
+      "integrity": "sha512-Eix+sb/Nj28MNnWvO2X1OLrk5vuD4C9SMnb2Vf4itWnxphYeSceqkFX7IdmxTzn+dvmnNz7paMbg4Uc60wSfJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@aws-sdk/client-ses": "^3.731.1",
         "@types/node": "*"
       }
     },
@@ -2550,24 +3890,22 @@
       }
     },
     "node_modules/@types/send": {
-      "version": "0.17.5",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
-      "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
       "license": "MIT",
       "dependencies": {
-        "@types/mime": "^1",
         "@types/node": "*"
       }
     },
     "node_modules/@types/serve-static": {
-      "version": "1.15.8",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.8.tgz",
-      "integrity": "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
-        "@types/node": "*",
-        "@types/send": "*"
+        "@types/node": "*"
       }
     },
     "node_modules/@types/sizzle": {
@@ -2616,9 +3954,9 @@
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.33",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
-      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2912,6 +4250,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
       "dependencies": {
         "mime-types": "^3.0.0",
         "negotiator": "^1.0.0"
@@ -2925,6 +4264,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2958,6 +4298,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -2975,9 +4325,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2987,12 +4337,15 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
       "engines": {
-        "node": ">=12"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -3053,22 +4406,19 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "node_modules/array-flatten": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
-      "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA=="
-    },
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/assert-never": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.3.0.tgz",
-      "integrity": "sha512-9Z3vxQ+berkL/JJo0dK+EY3Lp0s3NtSnP3VCLsh5HDcZPrh0M+KQRK5sWhUeyPPH+/RCxZqOxLMR+YC6vlviEQ==",
-      "dev": true
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.4.0.tgz",
+      "integrity": "sha512-5oJg84os6NMQNl27T9LnZkvvqzvAnHu03ShCnoj6bsJwS7L8AO4lf+C/XjK/nvzEqQB744moC6V128RucQd1jA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -3096,21 +4446,22 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
       "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 6.0.0"
       }
     },
     "node_modules/babel-jest": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.1.2.tgz",
-      "integrity": "sha512-IQCus1rt9kaSh7PQxLYRY5NmkNrNlU2TpabzwV7T2jljnpdHOcmnYYv8QmE04Li4S3a2Lj8/yXyET5pBarPr6g==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.2.0.tgz",
+      "integrity": "sha512-0YiBEOxWqKkSQWL9nNGGEgndoeL0ZpWrbLMNL5u/Kaxrli3Eaxlt3ZtIDktEvXt4L/R9r3ODr2zKwGM/2BjxVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/transform": "30.1.2",
+        "@jest/transform": "30.2.0",
         "@types/babel__core": "^7.20.5",
-        "babel-plugin-istanbul": "^7.0.0",
-        "babel-preset-jest": "30.0.1",
+        "babel-plugin-istanbul": "^7.0.1",
+        "babel-preset-jest": "30.2.0",
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
         "slash": "^3.0.0"
@@ -3119,7 +4470,7 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.11.0"
+        "@babel/core": "^7.11.0 || ^8.0.0-0"
       }
     },
     "node_modules/babel-plugin-istanbul": {
@@ -3143,14 +4494,12 @@
       }
     },
     "node_modules/babel-plugin-jest-hoist": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.0.1.tgz",
-      "integrity": "sha512-zTPME3pI50NsFW8ZBaVIOeAxzEY7XHlmWeXXu9srI+9kNfzCUTy8MFan46xOGZY8NZThMqq+e3qZUKsvXbasnQ==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.2.0.tgz",
+      "integrity": "sha512-ftzhzSGMUnOzcCXd6WHdBGMyuwy15Wnn0iyyWGKgBDLxf9/s5ABuraCSpBX2uG0jUg4rqJnxsLc5+oYBqoxVaA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.27.3",
         "@types/babel__core": "^7.20.5"
       },
       "engines": {
@@ -3185,20 +4534,20 @@
       }
     },
     "node_modules/babel-preset-jest": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.0.1.tgz",
-      "integrity": "sha512-+YHejD5iTWI46cZmcc/YtX4gaKBtdqCHCVfuVinizVpbmyjO3zYmeuyFdfA8duRqQZfgCAMlsfmkVbJ+e2MAJw==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.2.0.tgz",
+      "integrity": "sha512-US4Z3NOieAQumwFnYdUWKvUKh8+YSnS/gB3t6YBiz0bskpu7Pine8pPCheNxlPEW4wnUkma2a94YuW2q3guvCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "babel-plugin-jest-hoist": "30.0.1",
-        "babel-preset-current-node-syntax": "^1.1.0"
+        "babel-plugin-jest-hoist": "30.2.0",
+        "babel-preset-current-node-syntax": "^1.2.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.11.0"
+        "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
       }
     },
     "node_modules/babel-walk": {
@@ -3206,6 +4555,7 @@
       "resolved": "https://registry.npmjs.org/babel-walk/-/babel-walk-3.0.0-canary-5.tgz",
       "integrity": "sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.9.6"
       },
@@ -3239,10 +4589,21 @@
       ],
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.3.tgz",
+      "integrity": "sha512-8QdH6czo+G7uBsNo0GiUfouPN1lRzKdJTGnKXwe12gkFbnnOUaUKGN55dMkfy+mnxmvjwl9zcI4VncczcVXDhA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
     "node_modules/basic-auth": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
       "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.1.2"
       },
@@ -3253,12 +4614,14 @@
     "node_modules/basic-auth/node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
     },
     "node_modules/bcryptjs": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
-      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ=="
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "license": "MIT"
     },
     "node_modules/bidi-js": {
       "version": "1.0.3",
@@ -3284,75 +4647,27 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.0.2.tgz",
-      "integrity": "sha512-SNMk0OONlQ01uk8EPeiBvTW7W4ovpL5b1O3t1sjpPgfxOQ6BqQJ6XjxinDPR79Z6HdcD5zBBwr5ssiTlgdNztQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.1.tgz",
+      "integrity": "sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==",
+      "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "3.1.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.5.2",
-        "on-finished": "2.4.1",
-        "qs": "6.13.0",
-        "raw-body": "^3.0.0",
-        "type-is": "~1.6.18"
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/body-parser/node_modules/debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/body-parser/node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/body-parser/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/body-parser/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dependencies": {
-        "mime-db": "1.52.0"
       },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/body-parser/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-    },
-    "node_modules/body-parser/node_modules/type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
-      },
-      "engines": {
-        "node": ">= 0.6"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/bootstrap": {
@@ -3373,6 +4688,13 @@
       "peerDependencies": {
         "@popperjs/core": "^2.11.8"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.13.1.tgz",
+      "integrity": "sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
@@ -3397,9 +4719,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.25.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.4.tgz",
-      "integrity": "sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
       "dev": true,
       "funding": [
         {
@@ -3416,12 +4738,12 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "caniuse-lite": "^1.0.30001737",
-        "electron-to-chromium": "^1.5.211",
-        "node-releases": "^2.0.19",
-        "update-browserslist-db": "^1.1.3"
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3498,6 +4820,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -3570,9 +4893,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001741",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001741.tgz",
-      "integrity": "sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==",
+      "version": "1.0.30001759",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001759.tgz",
+      "integrity": "sha512-Pzfx9fOKoKvevQf8oCXoyNRQ5QyxJj+3O0Rqx2V5oxT61KGx8+n6hV/IUyJeifUci2clnmmKVpvtiqRzgiWjSw==",
       "dev": true,
       "funding": [
         {
@@ -3607,22 +4930,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/chalk/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/chalk/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -3651,6 +4958,7 @@
       "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
       "integrity": "sha512-+UqJQjFEFaTAs3bNsF2j2kEN1baG/zghZbdqoYEDxGZtJo9LBzl1A+m0D4n3qKx8N2FNv8/Xp6yV9mQmBuptaw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-regex": "^1.0.3"
       }
@@ -3681,9 +4989,9 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz",
-      "integrity": "sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
+      "integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
       "dev": true,
       "funding": [
         {
@@ -3697,9 +5005,9 @@
       }
     },
     "node_modules/cjs-module-lexer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.1.0.tgz",
-      "integrity": "sha512-UX0OwmYRYQQetfrLEZeewIFFI+wSTofC+pMBLNuH3RUuu/xzG1oz84UCEDOSoQlN3fZ4+AzmV50ZYvGqkMh9yA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.1.1.tgz",
+      "integrity": "sha512-+CmxIZ/L2vNcEfvNtLdU0ZQ6mbq3FZnwAP2PPTiKP+1QOoKwlKlPgb8UKV0Dds7QVaMnHm+FwSft2VB0s/SLjQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3724,21 +5032,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/cliui/node_modules/emoji-regex": {
@@ -3802,9 +5095,9 @@
       }
     },
     "node_modules/collect-v8-coverage": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
-      "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3872,19 +5165,18 @@
       }
     },
     "node_modules/concurrently": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.0.tgz",
-      "integrity": "sha512-IsB/fiXTupmagMW4MNp2lx2cdSN2FfZq78vF90LBB+zZHArbIQZjQtzXCiXnvTxCZSvXanTqFLWBjw2UkLx1SQ==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "^4.1.2",
-        "lodash": "^4.17.21",
-        "rxjs": "^7.8.1",
-        "shell-quote": "^1.8.1",
-        "supports-color": "^8.1.1",
-        "tree-kill": "^1.2.2",
-        "yargs": "^17.7.2"
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
       },
       "bin": {
         "conc": "dist/bin/concurrently.js",
@@ -3925,26 +5217,30 @@
       "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
       "integrity": "sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.6.0",
         "@babel/types": "^7.6.1"
       }
     },
     "node_modules/content-disposition": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/content-type": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -3960,6 +5256,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -3968,6 +5265,7 @@
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
       "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
       "dependencies": {
         "cookie": "0.7.2",
         "cookie-signature": "1.0.6"
@@ -3979,7 +5277,8 @@
     "node_modules/cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookiejar": {
       "version": "2.1.4",
@@ -4015,89 +5314,6 @@
       "engines": {
         "node": "^20.0.0 || >=22.0.0",
         "npm": ">=10"
-      }
-    },
-    "node_modules/cpx2/node_modules/glob": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
-      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "foreground-child": "^3.3.1",
-        "jackspeak": "^4.1.1",
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/cpx2/node_modules/jackspeak": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
-      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/cpx2/node_modules/lru-cache": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
-      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/cpx2/node_modules/minimatch": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/cpx2/node_modules/path-scurry": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
-      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/create-require": {
@@ -4155,9 +5371,9 @@
       }
     },
     "node_modules/cssstyle": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.0.tgz",
-      "integrity": "sha512-RveJPnk3m7aarYQ2bJ6iw+Urh55S6FzUiqtBq+TihnTDP4cI8y/TYDqGOyqgnG1J1a6BxJXZsV9JFSTulm9Z7g==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.3.tgz",
+      "integrity": "sha512-OytmFH+13/QXONJcC75QNdMtKpceNk3u8ThBjyyYjkEcy/ekBwR1mMAuNvi3gdBPW3N5TlCzQ0WZw8H0lN/bDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4203,9 +5419,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.13",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
-      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "version": "1.11.19",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
+      "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
       "license": "MIT"
     },
     "node_modules/debounce": {
@@ -4246,9 +5462,9 @@
       "license": "MIT"
     },
     "node_modules/dedent": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
-      "integrity": "sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.0.tgz",
+      "integrity": "sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==",
       "license": "MIT",
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
@@ -4273,6 +5489,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -4299,6 +5516,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
       "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10"
       }
@@ -4307,17 +5525,9 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/destroy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/detect-libc": {
@@ -4369,12 +5579,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
       "integrity": "sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dotenv": {
-      "version": "17.2.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
-      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -4414,12 +5625,13 @@
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.214",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.214.tgz",
-      "integrity": "sha512-TpvUNdha+X3ybfU78NoQatKvQEm1oq3lf2QbnmCEdw+Bd9RuIAY+hJTvq1avzHM0f7EJfnH3vbCnbzKzisc/9Q==",
+      "version": "1.5.266",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.266.tgz",
+      "integrity": "sha512-kgWEglXvkEfMH7rxP5OSZZwnaDWT7J9EoZCujhnpLbfi0bbNtRkgdX2E3gt0Uer11c61qCYktB3hwkAS325sJg==",
       "dev": true,
       "license": "ISC"
     },
@@ -4446,6 +5658,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -4464,9 +5677,9 @@
       }
     },
     "node_modules/error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4486,6 +5699,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -4519,9 +5733,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.6.tgz",
-      "integrity": "sha512-GVuzuUwtdsghE3ocJ9Bs8PNoF13HNQ5TXbEi2AhvVb8xU1Iwt9Fos9FEamfoee+u/TOsn7GUWc04lz46n2bbTg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -4532,32 +5746,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.6",
-        "@esbuild/android-arm": "0.25.6",
-        "@esbuild/android-arm64": "0.25.6",
-        "@esbuild/android-x64": "0.25.6",
-        "@esbuild/darwin-arm64": "0.25.6",
-        "@esbuild/darwin-x64": "0.25.6",
-        "@esbuild/freebsd-arm64": "0.25.6",
-        "@esbuild/freebsd-x64": "0.25.6",
-        "@esbuild/linux-arm": "0.25.6",
-        "@esbuild/linux-arm64": "0.25.6",
-        "@esbuild/linux-ia32": "0.25.6",
-        "@esbuild/linux-loong64": "0.25.6",
-        "@esbuild/linux-mips64el": "0.25.6",
-        "@esbuild/linux-ppc64": "0.25.6",
-        "@esbuild/linux-riscv64": "0.25.6",
-        "@esbuild/linux-s390x": "0.25.6",
-        "@esbuild/linux-x64": "0.25.6",
-        "@esbuild/netbsd-arm64": "0.25.6",
-        "@esbuild/netbsd-x64": "0.25.6",
-        "@esbuild/openbsd-arm64": "0.25.6",
-        "@esbuild/openbsd-x64": "0.25.6",
-        "@esbuild/openharmony-arm64": "0.25.6",
-        "@esbuild/sunos-x64": "0.25.6",
-        "@esbuild/win32-arm64": "0.25.6",
-        "@esbuild/win32-ia32": "0.25.6",
-        "@esbuild/win32-x64": "0.25.6"
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "node_modules/escalade": {
@@ -4572,7 +5786,8 @@
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "2.0.0",
@@ -4602,6 +5817,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -4648,63 +5864,64 @@
       }
     },
     "node_modules/expect": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-30.1.2.tgz",
-      "integrity": "sha512-xvHszRavo28ejws8FpemjhwswGj4w/BetHIL8cU49u4sGyXDw2+p3YbeDbj6xzlxi6kWTjIRSTJ+9sNXPnF0Zg==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.2.0.tgz",
+      "integrity": "sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/expect-utils": "30.1.2",
+        "@jest/expect-utils": "30.2.0",
         "@jest/get-type": "30.1.0",
-        "jest-matcher-utils": "30.1.2",
-        "jest-message-util": "30.1.0",
-        "jest-mock": "30.0.5",
-        "jest-util": "30.0.5"
+        "jest-matcher-utils": "30.2.0",
+        "jest-message-util": "30.2.0",
+        "jest-mock": "30.2.0",
+        "jest-util": "30.2.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/express": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.0.1.tgz",
-      "integrity": "sha512-ORF7g6qGnD+YtUG9yx4DFoqCShNMmUKiXuT5oWMHiOvt/4WFbHC6yCwQMTSBMno7AqntNCAzzcnnjowRkTL9eQ==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
-        "body-parser": "^2.0.1",
+        "body-parser": "^2.2.1",
         "content-disposition": "^1.0.0",
-        "content-type": "~1.0.4",
-        "cookie": "0.7.1",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
         "cookie-signature": "^1.2.1",
-        "debug": "4.3.6",
-        "depd": "2.0.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "^2.0.0",
-        "fresh": "2.0.0",
-        "http-errors": "2.0.0",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
         "merge-descriptors": "^2.0.0",
-        "methods": "~1.1.2",
         "mime-types": "^3.0.0",
-        "on-finished": "2.4.1",
-        "once": "1.4.0",
-        "parseurl": "~1.3.3",
-        "proxy-addr": "~2.0.7",
-        "qs": "6.13.0",
-        "range-parser": "~1.2.1",
-        "router": "^2.0.0",
-        "safe-buffer": "5.2.1",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
         "send": "^1.1.0",
-        "serve-static": "^2.1.0",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "type-is": "^2.0.0",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express-flash": {
@@ -4758,12 +5975,14 @@
     "node_modules/express-session/node_modules/cookie-signature": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
-      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
     },
     "node_modules/express-session/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -4771,7 +5990,8 @@
     "node_modules/express-session/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/express-validator": {
       "version": "7.3.1",
@@ -4786,42 +6006,14 @@
         "node": ">= 8.0.0"
       }
     },
-    "node_modules/express/node_modules/cookie": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/express/node_modules/cookie-signature": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
       }
-    },
-    "node_modules/express/node_modules/debug": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/express/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -4836,6 +6028,25 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -4861,42 +6072,25 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.0.0.tgz",
-      "integrity": "sha512-MX6Zo2adDViYh+GcxxB1dpO43eypOGUOL12rLCOTMQv/DfIbpSJUy4oQIIZhVZkH9e+bZWKMon0XHFEju16tkQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
       "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "2.4.1",
-        "parseurl": "~1.3.3",
-        "statuses": "2.0.1",
-        "unpipe": "~1.0.0"
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/finalhandler/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/finalhandler/node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/finalhandler/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/find-index": {
       "version": "0.1.1",
@@ -4951,9 +6145,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5012,6 +6206,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -5020,14 +6215,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.3.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
-      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
+      "version": "11.3.2",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.2.tgz",
+      "integrity": "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5065,6 +6261,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5073,6 +6270,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
       "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "license": "MIT",
       "dependencies": {
         "is-property": "^1.0.2"
       }
@@ -5157,20 +6355,24 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "license": "ISC",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
         "minipass": "^7.1.2",
         "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
+        "path-scurry": "^2.0.0"
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -5256,6 +6458,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -5279,6 +6482,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -5293,6 +6497,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -5321,18 +6526,51 @@
       "license": "MIT"
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -5346,14 +6584,19 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.2.tgz",
-      "integrity": "sha512-kERHXvpSaB4aU3eANwidg79K8FlrN77m8G9V+0vOR3HYaRifrlwMEpT7ZBJqLSEIHnEgJTHcWK82wwLwwKwtag==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ieee754": {
@@ -5445,7 +6688,8 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/ip-address": {
       "version": "10.0.1",
@@ -5460,6 +6704,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }
@@ -5517,6 +6762,7 @@
       "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
       "integrity": "sha512-zMIXX63sxzG3XrkHkrAPvm/OVZVSCPNkwMHU8oTX7/U3AL78I0QXCEICXUM13BIa8TYGZ68PiTKfQz3yaTNr4A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "acorn": "^7.1.1",
         "object-assign": "^4.1.1"
@@ -5585,21 +6831,26 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g=="
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "license": "MIT"
     },
     "node_modules/is-regex": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5676,9 +6927,9 @@
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -5731,17 +6982,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-source-maps/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.30",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
-      "integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
     "node_modules/istanbul-reports": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
@@ -5757,32 +6997,32 @@
       }
     },
     "node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
+      "engines": {
+        "node": "20 || >=22"
+      },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jest": {
-      "version": "30.1.3",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-30.1.3.tgz",
-      "integrity": "sha512-Ry+p2+NLk6u8Agh5yVqELfUJvRfV51hhVBRIB5yZPY7mU0DGBmOuFG5GebZbMbm86cdQNK0fhJuDX8/1YorISQ==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-30.2.0.tgz",
+      "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@jest/core": "30.1.3",
-        "@jest/types": "30.0.5",
+        "@jest/core": "30.2.0",
+        "@jest/types": "30.2.0",
         "import-local": "^3.2.0",
-        "jest-cli": "30.1.3"
+        "jest-cli": "30.2.0"
       },
       "bin": {
         "jest": "bin/jest.js"
@@ -5800,14 +7040,14 @@
       }
     },
     "node_modules/jest-changed-files": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.0.5.tgz",
-      "integrity": "sha512-bGl2Ntdx0eAwXuGpdLdVYVr5YQHnSZlQ0y9HVDu565lCUAe9sj6JOtBbMmBBikGIegne9piDDIOeiLVoqTkz4A==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.2.0.tgz",
+      "integrity": "sha512-L8lR1ChrRnSdfeOvTrwZMlnWV8G/LLjQ0nG9MBclwWZidA2N5FviRki0Bvh20WRMOX31/JYvzdqTJrk5oBdydQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "execa": "^5.1.1",
-        "jest-util": "30.0.5",
+        "jest-util": "30.2.0",
         "p-limit": "^3.1.0"
       },
       "engines": {
@@ -5815,29 +7055,29 @@
       }
     },
     "node_modules/jest-circus": {
-      "version": "30.1.3",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.1.3.tgz",
-      "integrity": "sha512-Yf3dnhRON2GJT4RYzM89t/EXIWNxKTpWTL9BfF3+geFetWP4XSvJjiU1vrWplOiUkmq8cHLiwuhz+XuUp9DscA==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.2.0.tgz",
+      "integrity": "sha512-Fh0096NC3ZkFx05EP2OXCxJAREVxj1BcW/i6EWqqymcgYKWjyyDpral3fMxVcHXg6oZM7iULer9wGRFvfpl+Tg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.1.2",
-        "@jest/expect": "30.1.2",
-        "@jest/test-result": "30.1.3",
-        "@jest/types": "30.0.5",
+        "@jest/environment": "30.2.0",
+        "@jest/expect": "30.2.0",
+        "@jest/test-result": "30.2.0",
+        "@jest/types": "30.2.0",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "co": "^4.6.0",
         "dedent": "^1.6.0",
         "is-generator-fn": "^2.1.0",
-        "jest-each": "30.1.0",
-        "jest-matcher-utils": "30.1.2",
-        "jest-message-util": "30.1.0",
-        "jest-runtime": "30.1.3",
-        "jest-snapshot": "30.1.2",
-        "jest-util": "30.0.5",
+        "jest-each": "30.2.0",
+        "jest-matcher-utils": "30.2.0",
+        "jest-message-util": "30.2.0",
+        "jest-runtime": "30.2.0",
+        "jest-snapshot": "30.2.0",
+        "jest-util": "30.2.0",
         "p-limit": "^3.1.0",
-        "pretty-format": "30.0.5",
+        "pretty-format": "30.2.0",
         "pure-rand": "^7.0.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.6"
@@ -5847,21 +7087,21 @@
       }
     },
     "node_modules/jest-cli": {
-      "version": "30.1.3",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.1.3.tgz",
-      "integrity": "sha512-G8E2Ol3OKch1DEeIBl41NP7OiC6LBhfg25Btv+idcusmoUSpqUkbrneMqbW9lVpI/rCKb/uETidb7DNteheuAQ==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.2.0.tgz",
+      "integrity": "sha512-Os9ukIvADX/A9sLt6Zse3+nmHtHaE6hqOsjQtNiugFTbKRHYIYtZXNGNK9NChseXy7djFPjndX1tL0sCTlfpAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/core": "30.1.3",
-        "@jest/test-result": "30.1.3",
-        "@jest/types": "30.0.5",
+        "@jest/core": "30.2.0",
+        "@jest/test-result": "30.2.0",
+        "@jest/types": "30.2.0",
         "chalk": "^4.1.2",
         "exit-x": "^0.2.2",
         "import-local": "^3.2.0",
-        "jest-config": "30.1.3",
-        "jest-util": "30.0.5",
-        "jest-validate": "30.1.0",
+        "jest-config": "30.2.0",
+        "jest-util": "30.2.0",
+        "jest-validate": "30.2.0",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -5880,34 +7120,34 @@
       }
     },
     "node_modules/jest-config": {
-      "version": "30.1.3",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.1.3.tgz",
-      "integrity": "sha512-M/f7gqdQEPgZNA181Myz+GXCe8jXcJsGjCMXUzRj22FIXsZOyHNte84e0exntOvdPaeh9tA0w+B8qlP2fAezfw==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.2.0.tgz",
+      "integrity": "sha512-g4WkyzFQVWHtu6uqGmQR4CQxz/CH3yDSlhzXMWzNjDx843gYjReZnMRanjRCq5XZFuQrGDxgUaiYWE8BRfVckA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/get-type": "30.1.0",
         "@jest/pattern": "30.0.1",
-        "@jest/test-sequencer": "30.1.3",
-        "@jest/types": "30.0.5",
-        "babel-jest": "30.1.2",
+        "@jest/test-sequencer": "30.2.0",
+        "@jest/types": "30.2.0",
+        "babel-jest": "30.2.0",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
         "deepmerge": "^4.3.1",
         "glob": "^10.3.10",
         "graceful-fs": "^4.2.11",
-        "jest-circus": "30.1.3",
-        "jest-docblock": "30.0.1",
-        "jest-environment-node": "30.1.2",
+        "jest-circus": "30.2.0",
+        "jest-docblock": "30.2.0",
+        "jest-environment-node": "30.2.0",
         "jest-regex-util": "30.0.1",
-        "jest-resolve": "30.1.3",
-        "jest-runner": "30.1.3",
-        "jest-util": "30.0.5",
-        "jest-validate": "30.1.0",
+        "jest-resolve": "30.2.0",
+        "jest-runner": "30.2.0",
+        "jest-util": "30.2.0",
+        "jest-validate": "30.2.0",
         "micromatch": "^4.0.8",
         "parse-json": "^5.2.0",
-        "pretty-format": "30.0.5",
+        "pretty-format": "30.2.0",
         "slash": "^3.0.0",
         "strip-json-comments": "^3.1.1"
       },
@@ -5931,26 +7171,103 @@
         }
       }
     },
+    "node_modules/jest-config/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-config/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jest-config/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jest-config/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-config/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/jest-diff": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.1.2.tgz",
-      "integrity": "sha512-4+prq+9J61mOVXCa4Qp8ZjavdxzrWQXrI80GNxP8f4tkI2syPuPrJgdRPZRrfUTRvIoUwcmNLbqEJy9W800+NQ==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.2.0.tgz",
+      "integrity": "sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/diff-sequences": "30.0.1",
         "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
-        "pretty-format": "30.0.5"
+        "pretty-format": "30.2.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-docblock": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.0.1.tgz",
-      "integrity": "sha512-/vF78qn3DYphAaIc3jy4gA7XSAz167n9Bm/wn/1XhTLW7tTBIzXtCJpb/vcmc73NIIeeohCbdL94JasyXUZsGA==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.2.0.tgz",
+      "integrity": "sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5961,56 +7278,56 @@
       }
     },
     "node_modules/jest-each": {
-      "version": "30.1.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.1.0.tgz",
-      "integrity": "sha512-A+9FKzxPluqogNahpCv04UJvcZ9B3HamqpDNWNKDjtxVRYB8xbZLFuCr8JAJFpNp83CA0anGQFlpQna9Me+/tQ==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.2.0.tgz",
+      "integrity": "sha512-lpWlJlM7bCUf1mfmuqTA8+j2lNURW9eNafOy99knBM01i5CQeY5UH1vZjgT9071nDJac1M4XsbyI44oNOdhlDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
-        "@jest/types": "30.0.5",
+        "@jest/types": "30.2.0",
         "chalk": "^4.1.2",
-        "jest-util": "30.0.5",
-        "pretty-format": "30.0.5"
+        "jest-util": "30.2.0",
+        "pretty-format": "30.2.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-environment-node": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.1.2.tgz",
-      "integrity": "sha512-w8qBiXtqGWJ9xpJIA98M0EIoq079GOQRQUyse5qg1plShUCQ0Ek1VTTcczqKrn3f24TFAgFtT+4q3aOXvjbsuA==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.2.0.tgz",
+      "integrity": "sha512-ElU8v92QJ9UrYsKrxDIKCxu6PfNj4Hdcktcn0JX12zqNdqWHB0N+hwOnnBBXvjLd2vApZtuLUGs1QSY+MsXoNA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.1.2",
-        "@jest/fake-timers": "30.1.2",
-        "@jest/types": "30.0.5",
+        "@jest/environment": "30.2.0",
+        "@jest/fake-timers": "30.2.0",
+        "@jest/types": "30.2.0",
         "@types/node": "*",
-        "jest-mock": "30.0.5",
-        "jest-util": "30.0.5",
-        "jest-validate": "30.1.0"
+        "jest-mock": "30.2.0",
+        "jest-util": "30.2.0",
+        "jest-validate": "30.2.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-haste-map": {
-      "version": "30.1.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.1.0.tgz",
-      "integrity": "sha512-JLeM84kNjpRkggcGpQLsV7B8W4LNUWz7oDNVnY1Vjj22b5/fAb3kk3htiD+4Na8bmJmjJR7rBtS2Rmq/NEcADg==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.2.0.tgz",
+      "integrity": "sha512-sQA/jCb9kNt+neM0anSj6eZhLZUIhQgwDt7cPGjumgLM4rXsfb9kpnlacmvZz3Q5tb80nS+oG/if+NBKrHC+Xw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.0.5",
+        "@jest/types": "30.2.0",
         "@types/node": "*",
         "anymatch": "^3.1.3",
         "fb-watchman": "^2.0.2",
         "graceful-fs": "^4.2.11",
         "jest-regex-util": "30.0.1",
-        "jest-util": "30.0.5",
-        "jest-worker": "30.1.0",
+        "jest-util": "30.2.0",
+        "jest-worker": "30.2.0",
         "micromatch": "^4.0.8",
         "walker": "^1.0.8"
       },
@@ -6022,49 +7339,49 @@
       }
     },
     "node_modules/jest-leak-detector": {
-      "version": "30.1.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.1.0.tgz",
-      "integrity": "sha512-AoFvJzwxK+4KohH60vRuHaqXfWmeBATFZpzpmzNmYTtmRMiyGPVhkXpBqxUQunw+dQB48bDf4NpUs6ivVbRv1g==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.2.0.tgz",
+      "integrity": "sha512-M6jKAjyzjHG0SrQgwhgZGy9hFazcudwCNovY/9HPIicmNSBuockPSedAP9vlPK6ONFJ1zfyH/M2/YYJxOz5cdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
-        "pretty-format": "30.0.5"
+        "pretty-format": "30.2.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.1.2.tgz",
-      "integrity": "sha512-7ai16hy4rSbDjvPTuUhuV8nyPBd6EX34HkBsBcBX2lENCuAQ0qKCPb/+lt8OSWUa9WWmGYLy41PrEzkwRwoGZQ==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.2.0.tgz",
+      "integrity": "sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
-        "jest-diff": "30.1.2",
-        "pretty-format": "30.0.5"
+        "jest-diff": "30.2.0",
+        "pretty-format": "30.2.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-message-util": {
-      "version": "30.1.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.1.0.tgz",
-      "integrity": "sha512-HizKDGG98cYkWmaLUHChq4iN+oCENohQLb7Z5guBPumYs+/etonmNFlg1Ps6yN9LTPyZn+M+b/9BbnHx3WTMDg==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
+      "integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-        "@jest/types": "30.0.5",
+        "@jest/types": "30.2.0",
         "@types/stack-utils": "^2.0.3",
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
         "micromatch": "^4.0.8",
-        "pretty-format": "30.0.5",
+        "pretty-format": "30.2.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.6"
       },
@@ -6073,15 +7390,15 @@
       }
     },
     "node_modules/jest-mock": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.0.5.tgz",
-      "integrity": "sha512-Od7TyasAAQX/6S+QCbN6vZoWOMwlTtzzGuxJku1GhGanAjz9y+QsQkpScDmETvdc9aSXyJ/Op4rhpMYBWW91wQ==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
+      "integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.0.5",
+        "@jest/types": "30.2.0",
         "@types/node": "*",
-        "jest-util": "30.0.5"
+        "jest-util": "30.2.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -6116,18 +7433,18 @@
       }
     },
     "node_modules/jest-resolve": {
-      "version": "30.1.3",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.1.3.tgz",
-      "integrity": "sha512-DI4PtTqzw9GwELFS41sdMK32Ajp3XZQ8iygeDMWkxlRhm7uUTOFSZFVZABFuxr0jvspn8MAYy54NxZCsuCTSOw==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.2.0.tgz",
+      "integrity": "sha512-TCrHSxPlx3tBY3hWNtRQKbtgLhsXa1WmbJEqBlTBrGafd5fiQFByy2GNCEoGR+Tns8d15GaL9cxEzKOO3GEb2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.1.0",
+        "jest-haste-map": "30.2.0",
         "jest-pnp-resolver": "^1.2.3",
-        "jest-util": "30.0.5",
-        "jest-validate": "30.1.0",
+        "jest-util": "30.2.0",
+        "jest-validate": "30.2.0",
         "slash": "^3.0.0",
         "unrs-resolver": "^1.7.11"
       },
@@ -6136,47 +7453,46 @@
       }
     },
     "node_modules/jest-resolve-dependencies": {
-      "version": "30.1.3",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.1.3.tgz",
-      "integrity": "sha512-DNfq3WGmuRyHRHfEet+Zm3QOmVFtIarUOQHHryKPc0YL9ROfgWZxl4+aZq/VAzok2SS3gZdniP+dO4zgo59hBg==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.2.0.tgz",
+      "integrity": "sha512-xTOIGug/0RmIe3mmCqCT95yO0vj6JURrn1TKWlNbhiAefJRWINNPgwVkrVgt/YaerPzY3iItufd80v3lOrFJ2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "jest-regex-util": "30.0.1",
-        "jest-snapshot": "30.1.2"
+        "jest-snapshot": "30.2.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-runner": {
-      "version": "30.1.3",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.1.3.tgz",
-      "integrity": "sha512-dd1ORcxQraW44Uz029TtXj85W11yvLpDuIzNOlofrC8GN+SgDlgY4BvyxJiVeuabA1t6idjNbX59jLd2oplOGQ==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.2.0.tgz",
+      "integrity": "sha512-PqvZ2B2XEyPEbclp+gV6KO/F1FIFSbIwewRgmROCMBo/aZ6J1w8Qypoj2pEOcg3G2HzLlaP6VUtvwCI8dM3oqQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@jest/console": "30.1.2",
-        "@jest/environment": "30.1.2",
-        "@jest/test-result": "30.1.3",
-        "@jest/transform": "30.1.2",
-        "@jest/types": "30.0.5",
+        "@jest/console": "30.2.0",
+        "@jest/environment": "30.2.0",
+        "@jest/test-result": "30.2.0",
+        "@jest/transform": "30.2.0",
+        "@jest/types": "30.2.0",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "emittery": "^0.13.1",
         "exit-x": "^0.2.2",
         "graceful-fs": "^4.2.11",
-        "jest-docblock": "30.0.1",
-        "jest-environment-node": "30.1.2",
-        "jest-haste-map": "30.1.0",
-        "jest-leak-detector": "30.1.0",
-        "jest-message-util": "30.1.0",
-        "jest-resolve": "30.1.3",
-        "jest-runtime": "30.1.3",
-        "jest-util": "30.0.5",
-        "jest-watcher": "30.1.3",
-        "jest-worker": "30.1.0",
+        "jest-docblock": "30.2.0",
+        "jest-environment-node": "30.2.0",
+        "jest-haste-map": "30.2.0",
+        "jest-leak-detector": "30.2.0",
+        "jest-message-util": "30.2.0",
+        "jest-resolve": "30.2.0",
+        "jest-runtime": "30.2.0",
+        "jest-util": "30.2.0",
+        "jest-watcher": "30.2.0",
+        "jest-worker": "30.2.0",
         "p-limit": "^3.1.0",
         "source-map-support": "0.5.13"
       },
@@ -6185,37 +7501,114 @@
       }
     },
     "node_modules/jest-runtime": {
-      "version": "30.1.3",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.1.3.tgz",
-      "integrity": "sha512-WS8xgjuNSphdIGnleQcJ3AKE4tBKOVP+tKhCD0u+Tb2sBmsU8DxfbBpZX7//+XOz81zVs4eFpJQwBNji2Y07DA==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.2.0.tgz",
+      "integrity": "sha512-p1+GVX/PJqTucvsmERPMgCPvQJpFt4hFbM+VN3n8TMo47decMUcJbt+rgzwrEme0MQUA/R+1de2axftTHkKckg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.1.2",
-        "@jest/fake-timers": "30.1.2",
-        "@jest/globals": "30.1.2",
+        "@jest/environment": "30.2.0",
+        "@jest/fake-timers": "30.2.0",
+        "@jest/globals": "30.2.0",
         "@jest/source-map": "30.0.1",
-        "@jest/test-result": "30.1.3",
-        "@jest/transform": "30.1.2",
-        "@jest/types": "30.0.5",
+        "@jest/test-result": "30.2.0",
+        "@jest/transform": "30.2.0",
+        "@jest/types": "30.2.0",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "cjs-module-lexer": "^2.1.0",
         "collect-v8-coverage": "^1.0.2",
         "glob": "^10.3.10",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.1.0",
-        "jest-message-util": "30.1.0",
-        "jest-mock": "30.0.5",
+        "jest-haste-map": "30.2.0",
+        "jest-message-util": "30.2.0",
+        "jest-mock": "30.2.0",
         "jest-regex-util": "30.0.1",
-        "jest-resolve": "30.1.3",
-        "jest-snapshot": "30.1.2",
-        "jest-util": "30.0.5",
+        "jest-resolve": "30.2.0",
+        "jest-snapshot": "30.2.0",
+        "jest-util": "30.2.0",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jest-runtime/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/jest-serial-runner": {
@@ -6229,9 +7622,9 @@
       }
     },
     "node_modules/jest-snapshot": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.1.2.tgz",
-      "integrity": "sha512-4q4+6+1c8B6Cy5pGgFvjDy/Pa6VYRiGu0yQafKkJ9u6wQx4G5PqI2QR6nxTl43yy7IWsINwz6oT4o6tD12a8Dg==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.2.0.tgz",
+      "integrity": "sha512-5WEtTy2jXPFypadKNpbNkZ72puZCa6UjSr/7djeecHWOu7iYhSXSnHScT8wBz3Rn8Ena5d5RYRcsyKIeqG1IyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6240,20 +7633,20 @@
         "@babel/plugin-syntax-jsx": "^7.27.1",
         "@babel/plugin-syntax-typescript": "^7.27.1",
         "@babel/types": "^7.27.3",
-        "@jest/expect-utils": "30.1.2",
+        "@jest/expect-utils": "30.2.0",
         "@jest/get-type": "30.1.0",
-        "@jest/snapshot-utils": "30.1.2",
-        "@jest/transform": "30.1.2",
-        "@jest/types": "30.0.5",
-        "babel-preset-current-node-syntax": "^1.1.0",
+        "@jest/snapshot-utils": "30.2.0",
+        "@jest/transform": "30.2.0",
+        "@jest/types": "30.2.0",
+        "babel-preset-current-node-syntax": "^1.2.0",
         "chalk": "^4.1.2",
-        "expect": "30.1.2",
+        "expect": "30.2.0",
         "graceful-fs": "^4.2.11",
-        "jest-diff": "30.1.2",
-        "jest-matcher-utils": "30.1.2",
-        "jest-message-util": "30.1.0",
-        "jest-util": "30.0.5",
-        "pretty-format": "30.0.5",
+        "jest-diff": "30.2.0",
+        "jest-matcher-utils": "30.2.0",
+        "jest-message-util": "30.2.0",
+        "jest-util": "30.2.0",
+        "pretty-format": "30.2.0",
         "semver": "^7.7.2",
         "synckit": "^0.11.8"
       },
@@ -6262,9 +7655,9 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -6275,13 +7668,13 @@
       }
     },
     "node_modules/jest-util": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.0.5.tgz",
-      "integrity": "sha512-pvyPWssDZR0FlfMxCBoc0tvM8iUEskaRFALUtGQYzVEAqisAztmy+R8LnU14KT4XA0H/a5HMVTXat1jLne010g==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+      "integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.0.5",
+        "@jest/types": "30.2.0",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
@@ -6306,18 +7699,18 @@
       }
     },
     "node_modules/jest-validate": {
-      "version": "30.1.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.1.0.tgz",
-      "integrity": "sha512-7P3ZlCFW/vhfQ8pE7zW6Oi4EzvuB4sgR72Q1INfW9m0FGo0GADYlPwIkf4CyPq7wq85g+kPMtPOHNAdWHeBOaA==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.2.0.tgz",
+      "integrity": "sha512-FBGWi7dP2hpdi8nBoWxSsLvBFewKAg0+uSQwBaof4Y4DPgBabXgpSYC5/lR7VmnIlSpASmCi/ntRWPbv7089Pw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
-        "@jest/types": "30.0.5",
+        "@jest/types": "30.2.0",
         "camelcase": "^6.3.0",
         "chalk": "^4.1.2",
         "leven": "^3.1.0",
-        "pretty-format": "30.0.5"
+        "pretty-format": "30.2.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -6337,19 +7730,19 @@
       }
     },
     "node_modules/jest-watcher": {
-      "version": "30.1.3",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.1.3.tgz",
-      "integrity": "sha512-6jQUZCP1BTL2gvG9E4YF06Ytq4yMb4If6YoQGRR6PpjtqOXSP3sKe2kqwB6SQ+H9DezOfZaSLnmka1NtGm3fCQ==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.2.0.tgz",
+      "integrity": "sha512-PYxa28dxJ9g777pGm/7PrbnMeA0Jr7osHP9bS7eJy9DuAjMgdGtxgf0uKMyoIsTWAkIbUW5hSDdJ3urmgXBqxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/test-result": "30.1.3",
-        "@jest/types": "30.0.5",
+        "@jest/test-result": "30.2.0",
+        "@jest/types": "30.2.0",
         "@types/node": "*",
         "ansi-escapes": "^4.3.2",
         "chalk": "^4.1.2",
         "emittery": "^0.13.1",
-        "jest-util": "30.0.5",
+        "jest-util": "30.2.0",
         "string-length": "^4.0.2"
       },
       "engines": {
@@ -6357,15 +7750,15 @@
       }
     },
     "node_modules/jest-worker": {
-      "version": "30.1.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.1.0.tgz",
-      "integrity": "sha512-uvWcSjlwAAgIu133Tt77A05H7RIk3Ho8tZL50bQM2AkvLdluw9NG48lRCl3Dt+MOH719n/0nnb5YxUwcuJiKRA==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.2.0.tgz",
+      "integrity": "sha512-0Q4Uk8WF7BUwqXHuAjc23vmopWJw5WH7w2tqBoUOZpOjW/ZnR44GXXd1r82RvnmI2GZge3ivrYXk/BE2+VtW2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "@ungap/structured-clone": "^1.3.0",
-        "jest-util": "30.0.5",
+        "jest-util": "30.2.0",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.1.1"
       },
@@ -6387,9 +7780,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.0.tgz",
-      "integrity": "sha512-TTQJyoEoKcC1lscpVDCSsVgYzUDg/0Bt3WE//WiTPK6uOCQC2KZS4MpugbMWt/zyjkopgZoXhZuCi00gLudfUA==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -6399,7 +7792,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
       "integrity": "sha512-rtS5ATOo2Q5k1G+DADISilDA6lv79zIiwFd6CcjuIxGKLFm5C+RLImRscVap9k55i+MOZwgliw+NejvkLuGD5g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -6423,22 +7817,22 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "27.0.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.0.tgz",
-      "integrity": "sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==",
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.2.0.tgz",
+      "integrity": "sha512-454TI39PeRDW1LgpyLPyURtB4Zx1tklSr6+OFOipsxGUH1WMTvk6C65JQdrj455+DP2uJ1+veBEHTGFKWVLFoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/dom-selector": "^6.5.4",
-        "cssstyle": "^5.3.0",
+        "@acemir/cssom": "^0.9.23",
+        "@asamuzakjp/dom-selector": "^6.7.4",
+        "cssstyle": "^5.3.3",
         "data-urls": "^6.0.0",
-        "decimal.js": "^10.5.0",
+        "decimal.js": "^10.6.0",
         "html-encoding-sniffer": "^4.0.0",
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.6",
         "is-potential-custom-element-name": "^1.0.1",
-        "parse5": "^7.3.0",
-        "rrweb-cssom": "^0.8.0",
+        "parse5": "^8.0.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
         "tough-cookie": "^6.0.0",
@@ -6446,12 +7840,12 @@
         "webidl-conversions": "^8.0.0",
         "whatwg-encoding": "^3.1.1",
         "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^15.0.0",
-        "ws": "^8.18.2",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
         "canvas": "^3.0.0"
@@ -6462,42 +7856,17 @@
         }
       }
     },
-    "node_modules/jsdom/node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/jsdom/node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
+        "entities": "^6.0.0"
       },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/jsdom/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/jsesc": {
@@ -6551,6 +7920,7 @@
       "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-1.0.0.tgz",
       "integrity": "sha512-C9YK3Rf8q6VAPDCCU9fnqo3mAfOH6vUGnMcP4AQAYIEpWtfGLpwOTmZ+igtdK5y+VvI2n3CyYSzy4Qh34eq24A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-promise": "^2.0.0",
         "promise": "^7.0.1"
@@ -6600,22 +7970,26 @@
       "license": "MIT"
     },
     "node_modules/long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "engines": {
-        "node": ">=12"
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/lru.min": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.1.tgz",
-      "integrity": "sha512-FbAj6lXil6t8z4z3j0E5mfRlPzxkySotzUHwRXjlpRh10vc6AI6WN62ehZj82VG7M20rqogJ0GLwar2Xa05a8Q==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.3.tgz",
+      "integrity": "sha512-Lkk/vx6ak3rYkRR0Nhu4lFUT2VDnQSxBe8Hbl7f36358p6ow8Bnvr8lrLt98H8J1aGxfhbX4Fs5tYg2+FTwr5Q==",
+      "license": "MIT",
       "engines": {
         "bun": ">=1.0.0",
         "deno": ">=1.30.0",
@@ -6643,9 +8017,9 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -6692,6 +8066,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -6700,6 +8075,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -6718,6 +8094,8 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -6750,22 +8128,28 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.53.0.tgz",
-      "integrity": "sha512-oHlN/w+3MQ3rba9rqFr6V/ypF10LSkdwUysQL7GkXoTgIWeV+tcXGA852TBxH+gsh8UWoyhR1hKcoMJTuWflpg==",
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.0.tgz",
-      "integrity": "sha512-XqoSHeCGjVClAmoGFG3lVFqQFRIrTVw2OH3axRqAcfaw+gHWIfnASS92AV+Rl/mk0MupgZTRHQOjxY6YVnzK5w==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
       "dependencies": {
-        "mime-db": "^1.53.0"
+        "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/mimic-fn": {
@@ -6779,15 +8163,16 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "license": "ISC",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "@isaacs/brace-expansion": "^5.0.0"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -6843,6 +8228,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -6850,12 +8236,14 @@
     "node_modules/morgan/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/morgan/node_modules/on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+      "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -6866,7 +8254,8 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/multer": {
       "version": "2.0.2",
@@ -6930,14 +8319,15 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.11.4",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.11.4.tgz",
-      "integrity": "sha512-Z2o3tY4Z8EvSRDwknaC40MdZ3+m0sKbpnXrShQLdxPrAvcNli7jLrD2Zd2IzsRMw4eK9Yle500FDmlkIqp+krg==",
+      "version": "3.15.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.15.3.tgz",
+      "integrity": "sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==",
+      "license": "MIT",
       "dependencies": {
         "aws-ssl-profiles": "^1.1.1",
         "denque": "^2.1.0",
         "generate-function": "^2.3.1",
-        "iconv-lite": "^0.6.3",
+        "iconv-lite": "^0.7.0",
         "long": "^5.2.1",
         "lru.min": "^1.0.0",
         "named-placeholders": "^1.1.3",
@@ -6948,21 +8338,11 @@
         "node": ">= 8.0"
       }
     },
-    "node_modules/mysql2/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/named-placeholders": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.3.tgz",
       "integrity": "sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==",
+      "license": "MIT",
       "dependencies": {
         "lru-cache": "^7.14.1"
       },
@@ -6970,29 +8350,19 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
+    "node_modules/named-placeholders/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": ">=12"
       }
     },
     "node_modules/napi-postinstall": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.3.tgz",
-      "integrity": "sha512-uTp172LLXSxuSYHv/kou+f6KW3SMppU9ivthaVTXian9sOt3XM/zHYHpRZiLgQoxeWfYUnslNWQHF1+G71xcow==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -7016,6 +8386,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -7043,9 +8414,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.20.tgz",
-      "integrity": "sha512-7gK6zSXEH6neM212JgfYFXe+GmZQM+fia5SsusuBIUgnPheLFBmIPhtFoAQRj8/7wASYQnbDlHPVwY0BefoFgA==",
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -7171,9 +8542,9 @@
       }
     },
     "node_modules/oauth4webapi": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.1.tgz",
-      "integrity": "sha512-olkZDELNycOWQf9LrsELFq8n05LwJgV8UkrS0cburk6FOwf8GvLam+YB+Uj5Qvryee+vwWOfQVeI5Vm0MVg7SA==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.3.tgz",
+      "integrity": "sha512-pQ5BsX3QRTgnt5HxgHwgunIRaDXBdkT23tf8dfzmtTIL2LTpdmxgbpbBm0VgFWAIDlezQvQCTgnVIUmHupXHxw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -7183,14 +8554,16 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
-      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -7202,6 +8575,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -7222,6 +8596,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
       "dependencies": {
         "wrappy": "1"
       }
@@ -7243,13 +8618,13 @@
       }
     },
     "node_modules/openid-client": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.7.1.tgz",
-      "integrity": "sha512-kOiE4q0kNogr90hXsxPrKeEDuY+V0kkZazvZScOwZkYept9slsaQ3usXTaKkm6I04vLNuw5caBoX7UfrwC6x8w==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.1.tgz",
+      "integrity": "sha512-VoYT6enBo6Vj2j3Q5Ec0AezS+9YGzQo1f5Xc42lreMGlfP4ljiXPKVDvCADh+XHCV/bqPu/wWSiCVXbJKvrODw==",
       "license": "MIT",
       "dependencies": {
         "jose": "^6.1.0",
-        "oauth4webapi": "^3.8.0"
+        "oauth4webapi": "^3.8.2"
       },
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -7301,9 +8676,9 @@
       }
     },
     "node_modules/p-map": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
-      "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7365,6 +8740,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -7402,36 +8778,44 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.18"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-      "engines": {
-        "node": ">=16"
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/picocolors": {
@@ -7533,40 +8917,10 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/pretty-format": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.5.tgz",
-      "integrity": "sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+      "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7596,6 +8950,7 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "asap": "~2.0.3"
       }
@@ -7604,6 +8959,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -7641,6 +8997,7 @@
       "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-3.0.0.tgz",
       "integrity": "sha512-azINV9dUtzPMFQktvTXciNAfAuVh/L/JCl0vtPCwvOA21uZrC08K/UnmrL+SXGEVc1FwzjW62+xw5S/uaLj6cA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "constantinople": "^4.0.1",
         "js-stringify": "^1.0.2",
@@ -7652,6 +9009,7 @@
       "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.3.tgz",
       "integrity": "sha512-cYQg0JW0w32Ux+XTeZnBEeuWrAY7/HNE6TWnhiHGnnRYlCgyAUPoyh9KzCMa9WhcJlJ1AtQqpEYHc+vbCzA+Aw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "constantinople": "^4.0.1",
         "doctypes": "^1.1.0",
@@ -7667,13 +9025,15 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-2.1.0.tgz",
       "integrity": "sha512-lv7sU9e5Jk8IeUheHata6/UThZ7RK2jnaaNztxfPYUY+VxZyk/ePVaNZ/vwmH8WqGvDz3LrNYt/+gA55NDg6Pg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pug-filters": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
       "integrity": "sha512-yeNFtq5Yxmfz0f9z2rMXGw/8/4i1cCFecw/Q7+D0V2DdtII5UvqE12VaZ2AY7ri6o5RNXiweGH79OCq+2RQU4A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "constantinople": "^4.0.1",
         "jstransformer": "1.0.0",
@@ -7687,6 +9047,7 @@
       "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-5.0.1.tgz",
       "integrity": "sha512-0I6C62+keXlZPZkOJeVam9aBLVP2EnbeDw3An+k0/QlqdwH6rv8284nko14Na7c0TtqtogfWXcRoFE4O4Ff20w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "character-parser": "^2.2.0",
         "is-expression": "^4.0.0",
@@ -7698,6 +9059,7 @@
       "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
       "integrity": "sha512-gjD1yzp0yxbQqnzBAdlhbgoJL5qIFJw78juN1NpTLt/mfPJ5VgC4BvkoD3G23qKzJtIIXBbcCt6FioLSFLOHdw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "pug-error": "^2.0.0",
         "pug-walk": "^2.0.0"
@@ -7708,6 +9070,7 @@
       "resolved": "https://registry.npmjs.org/pug-load/-/pug-load-3.0.0.tgz",
       "integrity": "sha512-OCjTEnhLWZBvS4zni/WUMjH2YSUosnsmjGBB1An7CsKQarYSWQ0GCVyd4eQPMFJqZ8w9xgs01QdiZXKVjk92EQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "object-assign": "^4.1.1",
         "pug-walk": "^2.0.0"
@@ -7718,6 +9081,7 @@
       "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
       "integrity": "sha512-ukiYM/9cH6Cml+AOl5kETtM9NR3WulyVP2y4HOU45DyMim1IeP/OOiyEWRr6qk5I5klpsBnbuHpwKmTx6WURnw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "pug-error": "^2.0.0",
         "token-stream": "1.0.0"
@@ -7727,13 +9091,15 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-3.0.1.tgz",
       "integrity": "sha512-L50zbvrQ35TkpHwv0G6aLSuueDRwc/97XdY8kL3tOT0FmhgG7UypU3VztfV/LATAvmUfYi4wNxSajhSAeNN+Kg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pug-strip-comments": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
       "integrity": "sha512-zo8DsDpH7eTkPHCXFeAk1xZXJbyoTfdPlNR0bK7rpOMuhBYb0f5qUVCO1xlsitYd3w5FQTK7zpNVKb3rZoUrrQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "pug-error": "^2.0.0"
       }
@@ -7742,7 +9108,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-2.0.0.tgz",
       "integrity": "sha512-yYELe9Q5q9IQhuvqsZNwA5hfPkMJ8u92bQLIMcsMxf/VADjNtEYptU+inlufAFYcWdHlwNfZOEnOOQrZrcyJCQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -7772,11 +9139,12 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"
@@ -7789,6 +9157,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
       "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -7797,33 +9166,24 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/raw-body/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
+        "node": ">= 0.10"
       }
     },
     "node_modules/react-is": {
@@ -7887,13 +9247,13 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.10",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.16.0",
+        "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -7931,32 +9291,25 @@
       }
     },
     "node_modules/router": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/router/-/router-2.0.0.tgz",
-      "integrity": "sha512-dIM5zVoG8xhC6rnSN8uoAgFARwTE7BQs8YwHEvK0VCmfxQXMaOuA1uiR1IPwsW7JyK5iTt7Od/TC9StasS2NPQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
       "dependencies": {
-        "array-flatten": "3.0.0",
-        "is-promise": "4.0.0",
-        "methods": "~1.1.2",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "^8.0.0",
-        "setprototypeof": "1.2.0",
-        "utils-merge": "1.0.1"
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
       },
       "engines": {
-        "node": ">= 0.10"
+        "node": ">= 18"
       }
     },
     "node_modules/router/node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
-    },
-    "node_modules/rrweb-cssom": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
-      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
-      "dev": true,
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
     "node_modules/rxjs": {
@@ -7986,12 +9339,14 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/sass": {
       "version": "1.94.2",
@@ -8068,18 +9423,18 @@
       }
     },
     "node_modules/send": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.1.0.tgz",
-      "integrity": "sha512-v67WcEouB5GxbTWL/4NeToqcZiAWEq90N888fczVArY8A79J0L4FD7vj5hm3eUMua5EpoQ59wa/oovY6TLvRUA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.3.5",
-        "destroy": "^1.2.0",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
-        "fresh": "^0.5.2",
+        "fresh": "^2.0.0",
         "http-errors": "^2.0.0",
-        "mime-types": "^2.1.35",
+        "mime-types": "^3.0.1",
         "ms": "^2.1.3",
         "on-finished": "^2.4.1",
         "range-parser": "^1.2.1",
@@ -8089,47 +9444,21 @@
         "node": ">= 18"
       }
     },
-    "node_modules/send/node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/send/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/send/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/seq-queue": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
       "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
     },
     "node_modules/serve-static": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.1.0.tgz",
-      "integrity": "sha512-A3We5UfEjG8Z7VkDv6uItWw6HY2bBSBJT1KtVESn6EOoOr2jAxNhxWCLY3jDE2WcuHXByWju74ck3ZgLwL8xmA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "parseurl": "^1.3.3",
-        "send": "^1.0.0"
+        "send": "^1.2.0"
       },
       "engines": {
         "node": ">= 18"
@@ -8139,6 +9468,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -8154,7 +9484,8 @@
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/sha.js": {
       "version": "2.4.12",
@@ -8211,14 +9542,69 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "object-inspect": "^1.13.1"
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8333,6 +9719,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
       "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -8351,9 +9738,10 @@
       }
     },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -8472,9 +9860,9 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -8540,6 +9928,19 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/subarg": {
       "version": "1.0.0",
@@ -8607,6 +10008,7 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -8699,22 +10101,22 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.0.14",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.14.tgz",
-      "integrity": "sha512-lMNHE4aSI3LlkMUMicTmAG3tkkitjOQGDTFboPJwAg2kJXKP1ryWEyqujktg5qhrFZOkk5YFzgkxg3jErE+i5w==",
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.19.tgz",
+      "integrity": "sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.14"
+        "tldts-core": "^7.0.19"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.14",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.14.tgz",
-      "integrity": "sha512-viZGNK6+NdluOJWwTO9olaugx0bkKhscIdriQQ+lNNhwitIKvb+SvhbYgnCz6j9p7dX3cJntt4agQAKMXLjJ5g==",
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.19.tgz",
+      "integrity": "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==",
       "dev": true,
       "license": "MIT"
     },
@@ -8726,9 +10128,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/to-buffer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.1.tgz",
-      "integrity": "sha512-tB82LpAIWjhLYbqjx3X4zEeHN6M8CiuOEy2JY8SEQVdYRe3CCHOFaqrBW1doLDrfpWhplcW7BL+bO3/6S3pcDQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
       "license": "MIT",
       "dependencies": {
         "isarray": "^2.0.5",
@@ -8756,6 +10158,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.6"
       }
@@ -8764,7 +10167,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
       "integrity": "sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/touch": {
       "version": "3.1.1",
@@ -8790,16 +10194,16 @@
       }
     },
     "node_modules/tr46": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/tree-kill": {
@@ -8813,9 +10217,9 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.1.tgz",
-      "integrity": "sha512-SaeUtjfpg9Uqu8IbeDKtdaS0g8lS6FT6OzM3ezrDfErPJPHNDo/Ey+VFGP1bQIDfagYDLyRpd7O15XpG1Es2Uw==",
+      "version": "29.4.6",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
+      "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8825,7 +10229,7 @@
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.2",
+        "semver": "^7.7.3",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -8866,9 +10270,9 @@
       }
     },
     "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -8897,7 +10301,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -8979,9 +10382,10 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.0.tgz",
-      "integrity": "sha512-gd0sGezQYCbWSbkZr75mln4YBidWUN60+devscpLF5mtRDUpiaTvKpBNrdaCvel1NdR2k6vclXybU5fBd2i+nw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",
         "media-typer": "^1.1.0",
@@ -9016,7 +10420,6 @@
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.26.tgz",
       "integrity": "sha512-o2RrBNn3lczx1qv4j+JliVMmtkPSqEGpG0UuZkt9tCfWkoXKu8MZnjvp2GjWPll1SehwemQw6xrbVRhmOglj8Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^3.17.0",
@@ -9126,13 +10529,84 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/typeorm/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/typeorm/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/typeorm/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/typeorm/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/typeorm/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9159,6 +10633,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
       "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "license": "MIT",
       "dependencies": {
         "random-bytes": "~1.0.0"
       },
@@ -9174,9 +10649,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
     "node_modules/universalify": {
@@ -9193,6 +10668,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -9233,9 +10709,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.2.tgz",
+      "integrity": "sha512-E85pfNzMQ9jpKkA7+TJAi4TJN+tBCuWh5rUcS/sv6cFi+1q9LYDwDI5dpUL0u/73EElyQ8d3TEaeW4sPedBqYA==",
       "dev": true,
       "funding": [
         {
@@ -9268,14 +10744,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
-    },
-    "node_modules/utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
     },
     "node_modules/uuid": {
       "version": "11.1.0",
@@ -9312,17 +10780,6 @@
         "node": ">=10.12.0"
       }
     },
-    "node_modules/v8-to-istanbul/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.30",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
-      "integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
     "node_modules/validator": {
       "version": "13.15.23",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.23.tgz",
@@ -9336,6 +10793,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -9345,6 +10803,7 @@
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
       "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9419,13 +10878,13 @@
       }
     },
     "node_modules/whatwg-url": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.0.0.tgz",
-      "integrity": "sha512-+0q+Pc6oUhtbbeUfuZd4heMNOLDJDdagYxv756mCf9vnLF+NTj4zvv5UyYNkHJpc3CJIesMVoEIOdhi7L9RObA==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tr46": "^5.1.1",
+        "tr46": "^6.0.0",
         "webidl-conversions": "^8.0.0"
       },
       "engines": {
@@ -9473,6 +10932,7 @@
       "resolved": "https://registry.npmjs.org/with/-/with-7.0.2.tgz",
       "integrity": "sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.9.6",
         "@babel/types": "^7.9.6",
@@ -9534,21 +10994,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -9581,10 +11026,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/write-file-atomic": {
       "version": "5.0.1",

--- a/src/controller/eventController.ts
+++ b/src/controller/eventController.ts
@@ -306,6 +306,29 @@ async function deleteRegistration(event: Event, registrationId: string) {
     return await eventService.deleteRegistration(event.id, registrationId);
 }
 
+async function updateRegistrationDates(event: Event, registrationId: string, body: any, permData?: PermBundle) {
+    if (!permData?.entity.has('MANAGE_REGISTRATIONS')) {
+        throw new APIError('Not allowed', body, 403);
+    }
+
+    const schema = Joi.object({
+        arrivalDate: Joi.string().pattern(/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/).required(),
+        departureDate: Joi.string().pattern(/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/).required(),
+    });
+    const {error, value} = schema.validate(body, {abortEarly: false, allowUnknown: true});
+    if (error) {
+        const msg = error.details.map((d) => d.message).join(', ');
+        throw new APIError(msg, body, 400);
+    }
+
+    if (!isWithinWindow(event.startDate, event.endDate, value.arrivalDate, value.departureDate)) {
+        throw new APIError('Arrival/Departure must be within event dates', body, 400);
+    }
+
+    await eventService.updateRegistrationDates(event.id, Number(registrationId), value.arrivalDate, value.departureDate);
+    return 'Registration updated';
+}
+
 async function getParticipantsExtended(event: Event) {
     const participants = await eventService.getEventParticipants(event.id);
     const totals: Record<string, number> = {};
@@ -341,5 +364,6 @@ export default {
 
     getParticipants,
     deleteRegistration,
+    updateRegistrationDates,
     getParticipantsExtended,
 };

--- a/src/controller/eventController.ts
+++ b/src/controller/eventController.ts
@@ -306,11 +306,9 @@ async function deleteRegistration(event: Event, registrationId: string) {
     return await eventService.deleteRegistration(event.id, registrationId);
 }
 
+// Update registration arrival and departure dates
+// Note: Permission check for MANAGE_REGISTRATIONS is enforced at the route level
 async function updateRegistrationDates(event: Event, registrationId: string, body: any, permData?: PermBundle) {
-    if (!permData?.entity.has('MANAGE_REGISTRATIONS')) {
-        throw new APIError('Not allowed', body, 403);
-    }
-
     const schema = Joi.object({
         arrivalDate: Joi.string().pattern(/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/).required(),
         departureDate: Joi.string().pattern(/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/).required(),

--- a/src/controller/eventPoolController.ts
+++ b/src/controller/eventPoolController.ts
@@ -65,6 +65,7 @@ async function createInvoicePool(event: Event, body: any) {
         description: Joi.string().allow('').optional(),
         isDefault: Joi.alternatives().try(Joi.boolean(), Joi.string().valid('on', '')).default(false),
         assignAll: Joi.alternatives().try(Joi.boolean(), Joi.string().valid('on', '')).default(false),
+        subtractPersonalInvoices: Joi.alternatives().try(Joi.boolean(), Joi.string().valid('on', '')).default(true),
         registrations: Joi.alternatives().try(
             Joi.array().items(Joi.number().integer()),
             Joi.number().integer(),
@@ -77,11 +78,21 @@ async function createInvoicePool(event: Event, body: any) {
     // Default pools auto-attach to future participants without forcing current pools to be "assign all".
     const isDefault = value.isDefault === true || value.isDefault === 'on';
     const assignAll = value.assignAll === true || value.assignAll === 'on';
+    const subtractPersonalInvoices = value.subtractPersonalInvoices === true || value.subtractPersonalInvoices === 'on';
     const regIdsRaw = Array.isArray(value.registrations) ? value.registrations : (value.registrations ? [value.registrations] : []);
     const allowedIds = (await eventService.getRegistrationsForEvent(event.id)).map((r) => r.id);
     const regIds = assignAll ? allowedIds : regIdsRaw.filter((id: number) => allowedIds.includes(Number(id))).map(Number);
 
-    return invoiceService.createPool(event.id, value.name, value.description, value.distribution, isDefault, assignAll, regIds);
+    return invoiceService.createPool(
+        event.id,
+        value.name,
+        value.description,
+        value.distribution,
+        isDefault,
+        assignAll,
+        subtractPersonalInvoices,
+        regIds,
+    );
 }
 
 // Update pool assignments before closure, respecting default/assign-all toggles and allowed participants.
@@ -90,10 +101,15 @@ async function updatePoolAssignments(event: Event, poolId: string, body: any) {
     if (pool.status === 'CLOSED') throw new APIError('Pool is closed', body, 400);
     const isDefault = body.isDefault === true || body.isDefault === 'on';
     const assignAll = body.assignAll === true || body.assignAll === 'on';
+    const subtractPersonalInvoices = body.subtractPersonalInvoices === undefined
+        ? pool.subtractPersonalInvoices
+        : body.subtractPersonalInvoices === true || body.subtractPersonalInvoices === 'on';
     const regIdsRaw = Array.isArray(body.registrations) ? body.registrations : (body.registrations ? [body.registrations] : []);
+    const exemptIdsRaw = Array.isArray(body.exemptions) ? body.exemptions : (body.exemptions ? [body.exemptions] : []);
     const allowedIds = (await eventService.getRegistrationsForEvent(event.id)).map((r) => r.id);
     const regIds = assignAll ? allowedIds : regIdsRaw.map((id: any) => Number(id)).filter((id: number) => allowedIds.includes(id));
-    await invoiceService.updateAssignments(poolId, isDefault, assignAll, regIds);
+    const exemptIds = exemptIdsRaw.map((id: any) => Number(id)).filter((id: number) => allowedIds.includes(id));
+    await invoiceService.updateAssignments(poolId, isDefault, assignAll, subtractPersonalInvoices, regIds, exemptIds);
 }
 
 // Create a participant-specific surcharge that will be factored in during pool closure.
@@ -104,6 +120,7 @@ async function addPoolSurcharge(event: Event, poolId: string, body: any) {
         registrationId: Joi.number().integer().required(),
         amount: Joi.number().positive().required(),
         note: Joi.string().required(),
+        subtractFromPool: Joi.alternatives().try(Joi.boolean(), Joi.string().valid('on', '')).default(true),
     });
     const {error, value} = schema.validate(body, {abortEarly: false, allowUnknown: true});
     if (error) throw new APIError(error.message, body, 400);
@@ -112,7 +129,8 @@ async function addPoolSurcharge(event: Event, poolId: string, body: any) {
     const cleanedNote = (value.note as string).trim();
     if (!cleanedNote) throw new APIError('Note is required', body, 400);
     await assertRegistrationAllowed(pool, registrationId);
-    await invoiceService.addSurcharge(poolId, registrationId, Number(value.amount), cleanedNote);
+    const subtractFromPool = value.subtractFromPool === true || value.subtractFromPool === 'on';
+    await invoiceService.addSurcharge(poolId, registrationId, Number(value.amount), cleanedNote, subtractFromPool);
 }
 
 // Remove a surcharge so admins can correct mistakes before the pool closes.
@@ -276,10 +294,27 @@ async function approveInvoice(event: Event, poolId: string, invoiceId: string, s
 }
 
 // Close an approved invoice and inform the creator who performed the action.
-async function closeInvoice(event: Event, poolId: string, invoiceId: string, session: Request['session']) {
+async function closeInvoice(
+    event: Event,
+    poolId: string,
+    invoiceId: string,
+    session: Request['session'],
+    permData?: PermBundle,
+    allowManageOverride = true,
+) {
     const pool = await ensurePool(event, poolId);
     const invoice = await invoiceService.getInvoiceWithRegistration(poolId, Number(invoiceId));
     if (!invoice) throw new APIError('Invoice not found', {}, 404);
+    const actorRegId = await getActorRegistrationId(event, session);
+    const canManage = allowManageOverride && (permData?.entity?.has('MANAGE_ASSIGNMENTS') ?? false);
+    const isSubmitter = actorRegId === invoice.registration.id;
+    if (!canManage && !isSubmitter) {
+        throw new APIError('You may only close your own invoice', {}, 403);
+    }
+    if (!canManage && invoice.status !== 'APPROVED') {
+        throw new APIError('Invoices must be approved before closing', {}, 400);
+    }
+
     await invoiceService.closeInvoice(poolId, Number(invoiceId));
     const email = invoice.registration.user?.email || invoice.registration.guest?.email;
     if (email) {
@@ -312,8 +347,8 @@ async function closePool(event: Event, poolId: string, body: any = {}, session?:
     const pool = await ensurePool(event, poolId);
     if (pool.status === 'CLOSED') return;
 
-    const approvedInvoices = (pool.invoices || []).filter((inv) => inv.status === 'APPROVED');
-    const total = Number.parseFloat(pool.payableAmount);
+    const approvedInvoices = (pool.invoices || []).filter((inv) => inv.status !== 'NEW');
+    const total = toAmount(pool.payableAmount);
 
     // Pull full participant list once so we can reuse it for lookups and notifications
     const participants = await eventService.getEventParticipants(event.id);
@@ -326,6 +361,8 @@ async function closePool(event: Event, poolId: string, body: any = {}, session?:
     if (!targetRegistrations.length) throw new APIError('No participants assigned to this pool', {}, 400);
 
     const targetIds = new Set(targetRegistrations.map((r) => r.id));
+    const exemptIds = new Set((pool.assignments || []).filter((a) => a.isExempt).map((a) => a.registrationId));
+    const billableRegistrations = targetRegistrations.filter((reg) => !exemptIds.has(reg.id));
 
     // Bucket surcharges per participant so we can attribute them to a single payer later.
     const surchargeMap = new Map<number, { amount: number; note: string }[]>();
@@ -334,6 +371,13 @@ async function closePool(event: Event, poolId: string, body: any = {}, session?:
         const existing = surchargeMap.get(surcharge.registrationId) || [];
         existing.push({amount: toAmount(surcharge.amount), note: surcharge.note});
         surchargeMap.set(surcharge.registrationId, existing);
+    }
+
+    const invoiceCreditMap = new Map<number, number>();
+    for (const invoice of approvedInvoices) {
+        if (!targetIds.has(invoice.registrationId)) continue;
+        const running = invoiceCreditMap.get(invoice.registrationId) || 0;
+        invoiceCreditMap.set(invoice.registrationId, running + toAmount(invoice.amount));
     }
 
     // Respect pre-agreed takeovers; beneficiaries cannot also cover others by service validation
@@ -347,6 +391,7 @@ async function closePool(event: Event, poolId: string, body: any = {}, session?:
     const payerShares = new Map<number, {
         base: number;
         surcharges: number;
+        invoiceCredits: number;
         notes: string[];
         beneficiaries: number[];
         detailNotes: string[]
@@ -354,19 +399,19 @@ async function closePool(event: Event, poolId: string, body: any = {}, session?:
 
     let individualCosts;
     if (pool.distributionMethod === ("TIME_BASED" as InvoicePoolDistribution)) {
-        const individualDays = targetRegistrations.reduce((acc, reg) => {
+        const individualDays = billableRegistrations.reduce((acc, reg) => {
             acc.set(reg.id, differenceInCalendarDays(reg.departureDate, reg.arrivalDate) + 1)
             return acc;
         }, new Map<number, number>());
         const totalDays = Array.from(individualDays.values()).reduce((total, val) => total + val, 0);
-        const costPerDay = total / totalDays;
+        const costPerDay = totalDays ? total / totalDays : 0;
         individualCosts = Array.from(individualDays.entries()).reduce((acc, reg) => {
             acc.set(reg[0], {total: costPerDay * reg[1], days: reg[1]});
             return acc;
         }, new Map());
     } else if (pool.distributionMethod === ("EQUAL" as InvoicePoolDistribution)) {
-        const perPerson = targetRegistrations.length ? total / targetRegistrations.length : 0;
-        individualCosts = targetRegistrations.reduce((acc, reg) => {
+        const perPerson = billableRegistrations.length ? total / billableRegistrations.length : 0;
+        individualCosts = billableRegistrations.reduce((acc, reg) => {
             acc.set(reg.id, {total: perPerson});
             return acc;
         }, new Map())
@@ -374,22 +419,26 @@ async function closePool(event: Event, poolId: string, body: any = {}, session?:
 
     for (const registration of targetRegistrations) {
         const personalCost = individualCosts?.get(registration.id) || {};
-        const baseShare = personalCost.total || 0;
+        const baseShare = exemptIds.has(registration.id) ? 0 : (personalCost.total || 0);
         const extras = surchargeMap.get(registration.id) || [];
         const extraTotal = extras.reduce((sum, entry) => sum + entry.amount, 0);
+        const invoiceCredit = pool.subtractPersonalInvoices ? (invoiceCreditMap.get(registration.id) || 0) : 0;
         const payerId = takeoverMap.get(registration.id) ?? registration.id;
         const participantLabel = participantMap.get(registration.id)?.name || `Participant #${registration.id}`;
         const beneficiaryName = payerId !== registration.id ? participantLabel : null;
         const bucket = payerShares.get(payerId) || {
             base: 0,
             surcharges: 0,
+            invoiceCredits: 0,
             notes: [],
             beneficiaries: [],
             detailNotes: []
         };
         bucket.base += baseShare;
         bucket.surcharges += extraTotal;
+        bucket.invoiceCredits += invoiceCredit;
         bucket.detailNotes.push(`Base share for ${beneficiaryName || 'self'}: ${formatAmount(baseShare)}`);
+        if (exemptIds.has(registration.id)) bucket.detailNotes.push('Exempt from automatic share');
         if (personalCost.days) bucket.detailNotes.push(`(for ${personalCost.days} days)`);
         if (beneficiaryName) {
             bucket.beneficiaries.push(registration.id);
@@ -401,15 +450,20 @@ async function closePool(event: Event, poolId: string, body: any = {}, session?:
             bucket.detailNotes.push(`Surcharge for ${detailLabel}: ${formatAmount(entry.amount)}`);
             if (entry.note) bucket.notes.push(`Surcharge for ${adjustmentTarget}: ${entry.note}`);
         });
+        if (invoiceCredit) {
+            bucket.detailNotes.push(`Invoice credit for ${beneficiaryName || 'self'}: -${formatAmount(invoiceCredit)}`);
+        }
         payerShares.set(payerId, bucket);
     }
 
     const sharePayloads = Array.from(payerShares.entries()).map(([registrationId, data]) => {
-        const baseShareAmount = formatAmount(data.base);
-        const extraAmount = formatAmount(data.surcharges);
-        const shareAmount = formatAmount(data.base + data.surcharges);
+        const baseShareAmount = toAmount(data.base);
+        const extraAmount = toAmount(data.surcharges);
+        const invoiceCreditAmount = toAmount(data.invoiceCredits);
+        const shareValue = data.base + data.surcharges - data.invoiceCredits;
+        const shareAmount = toAmount(shareValue);
         const note = data.detailNotes.filter(Boolean).join(' • ') || undefined;
-        return {registrationId, baseShareAmount, extraAmount, shareAmount, note};
+        return {registrationId, baseShareAmount, extraAmount, invoiceCreditAmount, shareAmount, note};
     });
 
     await invoiceService.closePool(poolId, approvedInvoices.map((inv) => inv.id), sharePayloads);
@@ -425,10 +479,13 @@ async function closePool(event: Event, poolId: string, body: any = {}, session?:
             .join(', ');
         const detailLines = data.detailNotes.map((n) => `- ${n}`).join('\n');
         const noteText = data.detailNotes.length ? `\nBreakdown:\n${detailLines}` : '';
+        const totalDue = data.base + data.surcharges - data.invoiceCredits;
+        const verb = totalDue < 0 ? 'are owed' : 'owe';
+        const formattedTotal = formatAmount(Math.abs(totalDue));
         void mailer.sendEmail(
             email,
             'Invoice pool closed',
-            `You owe ${formatAmount(data.base + data.surcharges)} for pool "${sanitizeForEmail(pool.name)}"${coverageNames ? ` (covering ${coverageNames})` : ''}.\nActioned by ${actor}.${noteText}`
+            `You ${verb} ${formattedTotal} for pool "${sanitizeForEmail(pool.name)}"${coverageNames ? ` (covering ${coverageNames})` : ''}.\nActioned by ${actor}.${noteText}`
         );
     }
 }

--- a/src/controller/eventPoolController.ts
+++ b/src/controller/eventPoolController.ts
@@ -309,7 +309,7 @@ async function closeInvoice(
     const canManage = allowManageOverride && (permData?.entity?.has('MANAGE_ASSIGNMENTS') ?? false);
     const isSubmitter = actorRegId === invoice.registration.id;
     if (!canManage && !isSubmitter) {
-        throw new APIError('You may only close your own invoice', {}, 403);
+        throw new APIError('You can only close your own approved invoices, unless you are an administrator.', {}, 403);
     }
     if (!canManage && invoice.status !== 'APPROVED') {
         throw new APIError('Invoices must be approved before closing', {}, 400);
@@ -347,6 +347,8 @@ async function closePool(event: Event, poolId: string, body: any = {}, session?:
     const pool = await ensurePool(event, poolId);
     if (pool.status === 'CLOSED') return;
 
+    // Include all invoices whose status is not 'NEW' (APPROVED, DECLINED, CLOSED, etc.)
+    // This is required for pool closing logic, as all non-NEW invoices must be processed.
     const approvedInvoices = (pool.invoices || []).filter((inv) => inv.status !== 'NEW');
     const total = toAmount(pool.payableAmount);
 
@@ -373,6 +375,8 @@ async function closePool(event: Event, poolId: string, body: any = {}, session?:
         surchargeMap.set(surcharge.registrationId, existing);
     }
 
+    // Aggregate the total approved invoice amounts submitted by each participant.
+    // This will later be deducted from their calculated share if pool.subtractPersonalInvoices is enabled.
     const invoiceCreditMap = new Map<number, number>();
     for (const invoice of approvedInvoices) {
         if (!targetIds.has(invoice.registrationId)) continue;
@@ -422,6 +426,8 @@ async function closePool(event: Event, poolId: string, body: any = {}, session?:
         const baseShare = exemptIds.has(registration.id) ? 0 : (personalCost.total || 0);
         const extras = surchargeMap.get(registration.id) || [];
         const extraTotal = extras.reduce((sum, entry) => sum + entry.amount, 0);
+        // If subtractPersonalInvoices is enabled, participants receive credit for their submitted invoices.
+        // This reduces their share by the amount they've already contributed via invoices.
         const invoiceCredit = pool.subtractPersonalInvoices ? (invoiceCreditMap.get(registration.id) || 0) : 0;
         const payerId = takeoverMap.get(registration.id) ?? registration.id;
         const participantLabel = participantMap.get(registration.id)?.name || `Participant #${registration.id}`;
@@ -546,6 +552,29 @@ export async function serveInvoiceProof(event: Event, poolId: string, invoiceId:
     res.sendFile(fullPath);
 }
 
+// Recalculate a closed pool by deleting existing shares and re-running the closePool logic
+// This allows admins to adjust pool settings after closure and recalculate shares
+// The reopenPool and closePool operations use transactions with locks to prevent race conditions
+async function recalculatePool(event: Event, poolId: string, body: any = {}, session?: Request['session']) {
+    const pool = await ensurePool(event, poolId);
+    if (pool.status !== 'CLOSED') {
+        throw new APIError('Only closed pools can be recalculated', {}, 400);
+    }
+
+    try {
+        // Reopen the pool (uses SERIALIZABLE transaction with pessimistic write lock)
+        await invoiceService.reopenPool(poolId);
+        
+        // Re-run the close pool logic which will recalculate all shares
+        // closePool also uses transactions (READ COMMITTED) for share deletion and creation
+        await closePool(event, poolId, body, session);
+    } catch (error) {
+        // If recalculation fails after reopening, the pool will remain open
+        // Admins can fix issues and try closing again
+        throw error;
+    }
+}
+
 export default {
     purgeExpiredProofs,
     createInvoicePool,
@@ -557,6 +586,7 @@ export default {
     closeInvoice,
     declineInvoice,
     closePool,
+    recalculatePool,
     markSharePaid,
     updateTakeovers,
     serveInvoiceProof,

--- a/src/migrations/1754000000000-AddInvoicePoolCredits.ts
+++ b/src/migrations/1754000000000-AddInvoicePoolCredits.ts
@@ -1,0 +1,21 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class AddInvoicePoolCredits1754000000000 implements MigrationInterface {
+    name = 'AddInvoicePoolCredits1754000000000'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE event_invoice_pools ADD COLUMN subtract_personal_invoices TINYINT(1) NOT NULL DEFAULT 1`);
+        await queryRunner.query(`ALTER TABLE event_invoice_pools ADD COLUMN surcharge_offset_amount DECIMAL(10,2) NOT NULL DEFAULT 0.00`);
+        await queryRunner.query(`ALTER TABLE event_invoice_surcharges ADD COLUMN subtract_from_pool TINYINT(1) NOT NULL DEFAULT 1`);
+        await queryRunner.query(`ALTER TABLE event_invoice_assignments ADD COLUMN is_exempt TINYINT(1) NOT NULL DEFAULT 0`);
+        await queryRunner.query(`ALTER TABLE event_invoice_shares ADD COLUMN invoice_credit_amount DECIMAL(10,2) NOT NULL DEFAULT 0.00`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE event_invoice_shares DROP COLUMN invoice_credit_amount`);
+        await queryRunner.query(`ALTER TABLE event_invoice_assignments DROP COLUMN is_exempt`);
+        await queryRunner.query(`ALTER TABLE event_invoice_surcharges DROP COLUMN subtract_from_pool`);
+        await queryRunner.query(`ALTER TABLE event_invoice_pools DROP COLUMN surcharge_offset_amount`);
+        await queryRunner.query(`ALTER TABLE event_invoice_pools DROP COLUMN subtract_personal_invoices`);
+    }
+}

--- a/src/migrations/1754000000000-AddInvoicePoolCredits.ts
+++ b/src/migrations/1754000000000-AddInvoicePoolCredits.ts
@@ -4,11 +4,31 @@ export class AddInvoicePoolCredits1754000000000 implements MigrationInterface {
     name = 'AddInvoicePoolCredits1754000000000'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE event_invoice_pools ADD COLUMN subtract_personal_invoices TINYINT(1) NOT NULL DEFAULT 1`);
-        await queryRunner.query(`ALTER TABLE event_invoice_pools ADD COLUMN surcharge_offset_amount DECIMAL(10,2) NOT NULL DEFAULT 0.00`);
-        await queryRunner.query(`ALTER TABLE event_invoice_surcharges ADD COLUMN subtract_from_pool TINYINT(1) NOT NULL DEFAULT 1`);
-        await queryRunner.query(`ALTER TABLE event_invoice_assignments ADD COLUMN is_exempt TINYINT(1) NOT NULL DEFAULT 0`);
-        await queryRunner.query(`ALTER TABLE event_invoice_shares ADD COLUMN invoice_credit_amount DECIMAL(10,2) NOT NULL DEFAULT 0.00`);
+        // Make migration idempotent by checking if columns exist before adding
+        const hasSubtractPersonalInvoices = await queryRunner.hasColumn('event_invoice_pools', 'subtract_personal_invoices');
+        if (!hasSubtractPersonalInvoices) {
+            await queryRunner.query(`ALTER TABLE event_invoice_pools ADD COLUMN subtract_personal_invoices TINYINT(1) NOT NULL DEFAULT 1`);
+        }
+        
+        const hasSurchargeOffsetAmount = await queryRunner.hasColumn('event_invoice_pools', 'surcharge_offset_amount');
+        if (!hasSurchargeOffsetAmount) {
+            await queryRunner.query(`ALTER TABLE event_invoice_pools ADD COLUMN surcharge_offset_amount DECIMAL(10,2) NOT NULL DEFAULT 0.00`);
+        }
+        
+        const hasSubtractFromPool = await queryRunner.hasColumn('event_invoice_surcharges', 'subtract_from_pool');
+        if (!hasSubtractFromPool) {
+            await queryRunner.query(`ALTER TABLE event_invoice_surcharges ADD COLUMN subtract_from_pool TINYINT(1) NOT NULL DEFAULT 1`);
+        }
+        
+        const hasIsExempt = await queryRunner.hasColumn('event_invoice_assignments', 'is_exempt');
+        if (!hasIsExempt) {
+            await queryRunner.query(`ALTER TABLE event_invoice_assignments ADD COLUMN is_exempt TINYINT(1) NOT NULL DEFAULT 0`);
+        }
+        
+        const hasInvoiceCreditAmount = await queryRunner.hasColumn('event_invoice_shares', 'invoice_credit_amount');
+        if (!hasInvoiceCreditAmount) {
+            await queryRunner.query(`ALTER TABLE event_invoice_shares ADD COLUMN invoice_credit_amount DECIMAL(10,2) NOT NULL DEFAULT 0.00`);
+        }
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {

--- a/src/migrations/1755000000000-AddInvoicePoolCreditTracking.ts
+++ b/src/migrations/1755000000000-AddInvoicePoolCreditTracking.ts
@@ -1,0 +1,17 @@
+import {MigrationInterface, QueryRunner, TableColumn} from "typeorm";
+
+export class AddInvoicePoolCreditTracking1755000000000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.addColumn("event_invoice_pools", new TableColumn({
+            name: "credit_amount",
+            type: "decimal",
+            precision: 10,
+            scale: 2,
+            default: "0.00",
+        }));
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropColumn("event_invoice_pools", "credit_amount");
+    }
+}

--- a/src/migrations/1755000000000-AddInvoicePoolCreditTracking.ts
+++ b/src/migrations/1755000000000-AddInvoicePoolCreditTracking.ts
@@ -2,13 +2,17 @@ import {MigrationInterface, QueryRunner, TableColumn} from "typeorm";
 
 export class AddInvoicePoolCreditTracking1755000000000 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.addColumn("event_invoice_pools", new TableColumn({
-            name: "credit_amount",
-            type: "decimal",
-            precision: 10,
-            scale: 2,
-            default: "0.00",
-        }));
+        // Make migration idempotent by checking if column exists before adding
+        const hasCreditAmount = await queryRunner.hasColumn("event_invoice_pools", "credit_amount");
+        if (!hasCreditAmount) {
+            await queryRunner.addColumn("event_invoice_pools", new TableColumn({
+                name: "credit_amount",
+                type: "decimal",
+                precision: 10,
+                scale: 2,
+                default: "0.00",
+            }));
+        }
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {

--- a/src/modules/database/entities/event/EventInvoicePool.ts
+++ b/src/modules/database/entities/event/EventInvoicePool.ts
@@ -7,6 +7,13 @@ import {EventPoolTakeover} from "./EventPoolTakeover";
 import {EventInvoiceSurcharge} from "./EventInvoiceSurcharge";
 import type {InvoicePoolDistribution, InvoicePoolStatus} from "../../../../types/InvoicePoolTypes";
 
+import {formatAmount, toAmount} from "../../../lib/util";
+
+const currencyTransformer = {
+    to: (value: number | string) => formatAmount(toAmount(value)),
+    from: (value: string) => Number(value),
+};
+
 export const InvoicePoolDistributions = ['EQUAL', 'TIME_BASED'];
 
 @Entity("event_invoice_pools", {schema: "surveyor"})
@@ -40,22 +47,34 @@ export class EventInvoicePool {
     @Column("tinyint", {name: "assign_all", width: 1, default: 1})
     assignAll!: boolean;
 
-    @Column("decimal", {name: "total_amount", precision: 10, scale: 2, default: "0.00"})
-    totalAmount!: string;
+    // Toggle whether the submitter's invoices reduce their own share during distribution
+    @Column("tinyint", {name: "subtract_personal_invoices", width: 1, default: 1})
+    subtractPersonalInvoices!: boolean;
 
-    @Column("decimal", {name: "open_amount", precision: 10, scale: 2, default: "0.00"})
-    openAmount!: string;
+    @Column("decimal", {name: "total_amount", precision: 10, scale: 2, default: "0.00", transformer: currencyTransformer})
+    totalAmount!: number;
 
-    @Column("decimal", {name: "outstanding_amount", precision: 10, scale: 2, default: "0.00"})
-    outstandingAmount!: string;
+    @Column("decimal", {name: "open_amount", precision: 10, scale: 2, default: "0.00", transformer: currencyTransformer})
+    openAmount!: number;
+
+    @Column("decimal", {name: "outstanding_amount", precision: 10, scale: 2, default: "0.00", transformer: currencyTransformer})
+    outstandingAmount!: number;
+
+    // Portion of unpaid shares where participants have overpaid and are owed a payout
+    @Column("decimal", {name: "credit_amount", precision: 10, scale: 2, default: "0.00", transformer: currencyTransformer})
+    creditAmount!: number;
 
     // Additional per-participant charges added before closing the pool
-    @Column("decimal", {name: "additional_amount", precision: 10, scale: 2, default: "0.00"})
-    additionalAmount!: string;
+    @Column("decimal", {name: "additional_amount", precision: 10, scale: 2, default: "0.00", transformer: currencyTransformer})
+    additionalAmount!: number;
+
+    // Portion of the surcharges that is removed from the shared pool total
+    @Column("decimal", {name: "surcharge_offset_amount", precision: 10, scale: 2, default: "0.00", transformer: currencyTransformer})
+    surchargeOffsetAmount!: number;
 
     // Sum of invoices plus additional per-person charges
-    @Column("decimal", {name: "payable_amount", precision: 10, scale: 2, default: "0.00"})
-    payableAmount!: string;
+    @Column("decimal", {name: "payable_amount", precision: 10, scale: 2, default: "0.00", transformer: currencyTransformer})
+    payableAmount!: number;
 
     @Column("timestamp", {name: "closed_at", nullable: true})
     closedAt?: Date | null;

--- a/src/modules/database/entities/event/EventInvoicePool.ts
+++ b/src/modules/database/entities/event/EventInvoicePool.ts
@@ -6,13 +6,7 @@ import {EventInvoiceShare} from "./EventInvoiceShare";
 import {EventPoolTakeover} from "./EventPoolTakeover";
 import {EventInvoiceSurcharge} from "./EventInvoiceSurcharge";
 import type {InvoicePoolDistribution, InvoicePoolStatus} from "../../../../types/InvoicePoolTypes";
-
-import {formatAmount, toAmount} from "../../../lib/util";
-
-const currencyTransformer = {
-    to: (value: number | string) => formatAmount(toAmount(value)),
-    from: (value: string) => Number(value),
-};
+import {currencyTransformer} from "../../transformers";
 
 export const InvoicePoolDistributions = ['EQUAL', 'TIME_BASED'];
 

--- a/src/modules/database/entities/event/EventInvoiceShare.ts
+++ b/src/modules/database/entities/event/EventInvoiceShare.ts
@@ -1,6 +1,12 @@
 import {Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn, RelationId} from "typeorm";
 import {EventInvoicePool} from "./EventInvoicePool";
 import {EventRegistration} from "./EventRegistration";
+import {formatAmount, toAmount} from "../../../lib/util";
+
+const currencyTransformer = {
+    to: (value: number | string) => formatAmount(toAmount(value)),
+    from: (value: string) => Number(value),
+};
 
 @Entity("event_invoice_shares", {schema: "surveyor"})
 export class EventInvoiceShare {
@@ -21,15 +27,30 @@ export class EventInvoiceShare {
     @RelationId((share: EventInvoiceShare) => share.registration)
     registrationId!: number;
 
-    @Column("decimal", {name: "base_share_amount", precision: 10, scale: 2})
-    baseShareAmount!: string;
+    @Column("decimal", {
+        name: "base_share_amount",
+        precision: 10,
+        scale: 2,
+        transformer: currencyTransformer,
+    })
+    baseShareAmount!: number;
 
-    @Column("decimal", {name: "extra_amount", precision: 10, scale: 2, default: "0.00"})
-    extraAmount!: string;
+    @Column("decimal", {name: "extra_amount", precision: 10, scale: 2, default: "0.00", transformer: currencyTransformer})
+    extraAmount!: number;
+
+    // Amount of the participant's own invoices credited against their share
+    @Column("decimal", {
+        name: "invoice_credit_amount",
+        precision: 10,
+        scale: 2,
+        default: "0.00",
+        transformer: currencyTransformer,
+    })
+    invoiceCreditAmount!: number;
 
     // Store the fully burdened total (base + extras) that the payer owes
-    @Column("decimal", {name: "share_amount", precision: 10, scale: 2})
-    shareAmount!: string;
+    @Column("decimal", {name: "share_amount", precision: 10, scale: 2, transformer: currencyTransformer})
+    shareAmount!: number;
 
     @Column("text", {name: "note", nullable: true})
     note?: string | null;

--- a/src/modules/database/entities/event/EventInvoiceShare.ts
+++ b/src/modules/database/entities/event/EventInvoiceShare.ts
@@ -1,12 +1,7 @@
 import {Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn, RelationId} from "typeorm";
 import {EventInvoicePool} from "./EventInvoicePool";
 import {EventRegistration} from "./EventRegistration";
-import {formatAmount, toAmount} from "../../../lib/util";
-
-const currencyTransformer = {
-    to: (value: number | string) => formatAmount(toAmount(value)),
-    from: (value: string) => Number(value),
-};
+import {currencyTransformer} from "../../transformers";
 
 @Entity("event_invoice_shares", {schema: "surveyor"})
 export class EventInvoiceShare {

--- a/src/modules/database/entities/event/EventInvoiceSurcharge.ts
+++ b/src/modules/database/entities/event/EventInvoiceSurcharge.ts
@@ -33,6 +33,10 @@ export class EventInvoiceSurcharge {
     @Column("text", {name: "note"})
     note!: string;
 
+    // Whether this surcharge should be removed from the shared pool total
+    @Column("tinyint", {name: "subtract_from_pool", width: 1, default: 1})
+    subtractFromPool!: boolean;
+
     @Column("timestamp", {name: "created_at", default: () => "CURRENT_TIMESTAMP"})
     createdAt!: Date;
 }

--- a/src/modules/database/entities/event/EventPoolAssignment.ts
+++ b/src/modules/database/entities/event/EventPoolAssignment.ts
@@ -22,6 +22,10 @@ export class EventPoolAssignment {
     @RelationId((assignment: EventPoolAssignment) => assignment.registration)
     registrationId!: number;
 
+    // Exempt participants skip automatic share calculation but still allow manual surcharges
+    @Column("tinyint", {name: "is_exempt", width: 1, default: 0})
+    isExempt!: boolean;
+
     @Column("timestamp", {name: "created_at", default: () => "CURRENT_TIMESTAMP"})
     createdAt!: Date;
 }

--- a/src/modules/database/services/EventInvoiceService.ts
+++ b/src/modules/database/services/EventInvoiceService.ts
@@ -73,6 +73,7 @@ export async function createPool(
     distribution: InvoicePoolDistribution,
     isDefault: boolean,
     assignAll: boolean,
+    subtractPersonalInvoices: boolean,
     registrationIds: number[] = [],
 ) {
     return AppDataSource.transaction("READ COMMITTED", async (manager) => {
@@ -85,12 +86,15 @@ export async function createPool(
             distributionMethod: distribution,
             isDefault,
             assignAll,
+            subtractPersonalInvoices,
             status: "OPEN" as InvoicePoolStatus,
-            totalAmount: "0",
-            openAmount: "0",
-            outstandingAmount: "0",
-            additionalAmount: "0",
-            payableAmount: "0",
+            totalAmount: 0,
+            openAmount: 0,
+            outstandingAmount: 0,
+            creditAmount: 0,
+            additionalAmount: 0,
+            surchargeOffsetAmount: 0,
+            payableAmount: 0,
         });
         const saved = await poolRepo.save(pool);
         if (!assignAll && registrationIds.length) {
@@ -264,9 +268,10 @@ export async function closePool(
     approvedInvoiceIds: number[],
     sharePayloads: {
         registrationId: number;
-        baseShareAmount: string;
-        extraAmount: string;
-        shareAmount: string;
+        baseShareAmount: number;
+        extraAmount: number;
+        invoiceCreditAmount: number;
+        shareAmount: number;
         note?: string | null;
     }[],
 ) {
@@ -286,6 +291,7 @@ export async function closePool(
                 registration: {id: payload.registrationId} as EventRegistration,
                 baseShareAmount: payload.baseShareAmount,
                 extraAmount: payload.extraAmount,
+                invoiceCreditAmount: payload.invoiceCreditAmount,
                 shareAmount: payload.shareAmount,
                 note: payload.note || null,
                 isPaid: false,
@@ -304,7 +310,9 @@ export async function updateAssignments(
     poolId: string,
     isDefault: boolean,
     assignAll: boolean,
+    subtractPersonalInvoices: boolean,
     allowedRegistrationIds: number[],
+    exemptRegistrationIds: number[],
 ) {
     await AppDataSource.transaction("READ COMMITTED", async (manager) => {
         const poolRepo = manager.getRepository(EventInvoicePool);
@@ -317,20 +325,23 @@ export async function updateAssignments(
 
         pool.isDefault = isDefault;
         pool.assignAll = assignAll;
+        pool.subtractPersonalInvoices = subtractPersonalInvoices;
+        const validIds = allowedRegistrationIds.length
+            ? allowedRegistrationIds
+            : (await manager.getRepository(EventRegistration).find({where: {event: {id: pool.eventId}}})).map((r) => r.id);
         await assignmentRepo.delete({pool: {id: poolId}});
-        if (!pool.assignAll && allowedRegistrationIds.length) {
-            const rows = allowedRegistrationIds.map((id) => assignmentRepo.create({
+        const effectiveIds = pool.assignAll && !allowedRegistrationIds.length ? validIds : allowedRegistrationIds;
+        if (effectiveIds.length) {
+            const rows = effectiveIds.map((id) => assignmentRepo.create({
                 pool: {id: poolId} as EventInvoicePool,
                 registration: {id} as EventRegistration,
+                isExempt: exemptRegistrationIds.includes(id),
             }));
             await assignmentRepo.save(rows);
         }
 
         // Keep takeover mappings consistent with the new assignment scope.
         const invalidTakeovers = await takeoverRepo.find({where: {pool: {id: poolId}}});
-        const validIds = allowedRegistrationIds.length
-            ? allowedRegistrationIds
-            : (await manager.getRepository(EventRegistration).find({where: {event: {id: pool.eventId}}})).map((r) => r.id);
         const toDrop = invalidTakeovers.filter(
             (t) => !validIds.includes(t.payerRegistrationId) || !validIds.includes(t.beneficiaryRegistrationId),
         );
@@ -351,13 +362,20 @@ export async function updateAssignments(
 }
 
 // Add a participant-specific surcharge before closing the pool.
-export async function addSurcharge(poolId: string, registrationId: number, amount: number, note: string) {
+export async function addSurcharge(
+    poolId: string,
+    registrationId: number,
+    amount: number,
+    note: string,
+    subtractFromPool: boolean,
+) {
     const repo = AppDataSource.getRepository(EventInvoiceSurcharge);
     const row = repo.create({
         pool: {id: poolId} as EventInvoicePool,
         registration: {id: registrationId} as EventRegistration,
         amount: formatAmount(amount),
         note,
+        subtractFromPool,
     });
     await repo.save(row);
     await recalcPoolTotals(poolId);
@@ -403,15 +421,24 @@ export async function recalcPoolTotals(poolId: string) {
         .filter((inv) => inv.status === "APPROVED")
         .reduce((sum, inv) => sum + toAmount(inv.amount), 0);
     const extraAmount = surcharges.reduce((sum, s) => sum + toAmount(s.amount), 0);
+    const subtractiveAmount = surcharges
+        .filter((s) => s.subtractFromPool)
+        .reduce((sum, s) => sum + toAmount(s.amount), 0);
     const outstandingAmount = shares
         .filter((s) => !s.isPaid)
-        .reduce((sum, s) => sum + toAmount(s.shareAmount), 0);
+        .reduce((sum, s) => sum + Math.max(toAmount(s.shareAmount), 0), 0);
+    const creditAmount = shares
+        .filter((s) => !s.isPaid)
+        .reduce((sum, s) => sum + Math.abs(Math.min(toAmount(s.shareAmount), 0)), 0);
 
-    pool.totalAmount = formatAmount(invoiceTotal);
-    pool.additionalAmount = formatAmount(extraAmount);
-    pool.payableAmount = formatAmount(invoiceTotal - extraAmount);
-    pool.openAmount = formatAmount(openAmount);
-    pool.outstandingAmount = formatAmount(outstandingAmount);
+    pool.totalAmount = toAmount(invoiceTotal);
+    pool.additionalAmount = toAmount(extraAmount);
+    pool.surchargeOffsetAmount = toAmount(subtractiveAmount);
+    const payable = Math.max(invoiceTotal - subtractiveAmount, 0);
+    pool.payableAmount = toAmount(payable);
+    pool.openAmount = toAmount(openAmount);
+    pool.outstandingAmount = toAmount(outstandingAmount);
+    pool.creditAmount = toAmount(creditAmount);
     await poolRepo.save(pool);
 }
 

--- a/src/modules/database/services/EventInvoiceService.ts
+++ b/src/modules/database/services/EventInvoiceService.ts
@@ -306,6 +306,21 @@ export async function closePool(
     await recalcPoolTotals(poolId);
 }
 
+// Reopen a closed pool to allow recalculation of shares
+// Uses transaction to prevent race conditions during concurrent recalculation attempts
+export async function reopenPool(poolId: string) {
+    await AppDataSource.transaction("SERIALIZABLE", async (manager) => {
+        const poolRepo = manager.getRepository(EventInvoicePool);
+        const pool = await poolRepo.findOne({where: {id: poolId}, lock: {mode: "pessimistic_write"}});
+        if (!pool) throw new Error("Pool not found");
+        if (pool.status !== "CLOSED") throw new Error("Pool is not closed");
+        
+        pool.status = "OPEN";
+        pool.closedAt = null; // Clear closed timestamp for consistency
+        await poolRepo.save(pool);
+    });
+}
+
 export async function updateAssignments(
     poolId: string,
     isDefault: boolean,

--- a/src/modules/database/services/EventService.ts
+++ b/src/modules/database/services/EventService.ts
@@ -284,6 +284,15 @@ export async function deleteRegistration(eventId: string, regId: string | number
     return res?.affected ?? 0 > 0;
 }
 
+export async function updateRegistrationDates(eventId: string, regId: number, arrivalDate: string, departureDate: string) {
+    const repo = AppDataSource.getRepository(EventRegistration);
+    const reg = await repo.findOne({where: {id: regId, event: {id: eventId}}});
+    if (!reg) throw new ExpectedError('Registration not found', 'error', 404);
+    reg.arrivalDate = arrivalDate;
+    reg.departureDate = departureDate;
+    await repo.save(reg);
+}
+
 export async function isEventFull(eventId: string): Promise<boolean> {
     const eventRepo = AppDataSource.getRepository(Event);
     const regRepo = AppDataSource.getRepository(EventRegistration);

--- a/src/modules/database/transformers.ts
+++ b/src/modules/database/transformers.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared TypeORM transformers for common data type conversions.
+ */
+
+import {formatAmount, toAmount} from "../lib/util";
+
+/**
+ * Currency transformer for decimal columns.
+ * Converts numeric values to formatted decimal strings (2 decimal places) for database storage
+ * and back to numbers for application use.
+ */
+export const currencyTransformer = {
+    to: (value: number | string) => formatAmount(toAmount(value)),
+    from: (value: string) => Number(value),
+};

--- a/src/public/js/events.ts
+++ b/src/public/js/events.ts
@@ -297,7 +297,7 @@ export function initInvoiceAdmin(): void {
             }
             if (target.classList.contains('pool-recalculate')) {
                 requireManageAssignments('recalculate invoice pools');
-                if (!confirm("WARNING: This will delete all existing shares and recalculate them based on current pool settings. All participants will be notified again. This action cannot be undone. Are you sure you want to proceed?")) return
+                if (!confirm("WARNING: This will delete all existing shares and recalculate them based on current pool settings. All participants will be notified again. This action cannot be undone. Are you sure you want to proceed?")) return;
                 await post(`/api/event/${getEventId()}/invoice-pools/${target.dataset.id}/recalculate`);
                 showInlineAlert('success', 'Pool recalculated successfully');
                 return reloadAfterDelay(RELOAD_DELAY_MS);

--- a/src/public/js/events.ts
+++ b/src/public/js/events.ts
@@ -234,6 +234,8 @@ export function initInvoiceAdmin(): void {
                 if (checkbox) payload.assignAll = checkbox.checked ? 'on' : '';
                 const defaultBox = poolForm.querySelector('#defaultPool') as HTMLInputElement | null;
                 if (defaultBox) payload.isDefault = defaultBox.checked ? 'on' : '';
+                const subtractBox = poolForm.querySelector('#subtractPersonalInvoicesCreate') as HTMLInputElement | null;
+                if (subtractBox) payload.subtractPersonalInvoices = subtractBox.checked ? 'on' : '';
 
                 await post((poolForm as HTMLElement).dataset.api!, payload);
                 showInlineAlert('success', 'Pool created');
@@ -278,6 +280,11 @@ export function initInvoiceAdmin(): void {
             if (target.classList.contains('invoice-close')) {
                 requireManageAssignments('close invoices');
                 await post(`/api/event/${getEventId()}/invoice-pools/${target.dataset.pool}/invoices/${target.dataset.id}/close`);
+                showInlineAlert('success', 'Invoice closed');
+                return reloadAfterDelay(RELOAD_DELAY_MS);
+            }
+            if (target.classList.contains('invoice-close-self')) {
+                await post(`/api/event/${getEventId()}/invoice-pools/${target.dataset.pool}/invoices/${target.dataset.id}/close-self`);
                 showInlineAlert('success', 'Invoice closed');
                 return reloadAfterDelay(RELOAD_DELAY_MS);
             }
@@ -364,6 +371,19 @@ export function initInvoiceAdmin(): void {
                         input.removeAttribute('data-original-checked');
                     }
                 }
+            });
+        }
+    });
+
+    document.addEventListener('input', (e: Event) => {
+        const target = e.target as HTMLElement;
+        if (target.classList.contains('assignment-search')) {
+            const term = (target as HTMLInputElement).value.toLowerCase();
+            const list = target.closest('.pool-assignment')?.querySelector('.assignments-list');
+            if (!list) return;
+            list.querySelectorAll<HTMLElement>('[data-search-text]').forEach((row) => {
+                const text = (row.getAttribute('data-search-text') || '').toLowerCase();
+                row.classList.toggle('d-none', !!term && !text.includes(term));
             });
         }
     });

--- a/src/public/js/events.ts
+++ b/src/public/js/events.ts
@@ -295,6 +295,13 @@ export function initInvoiceAdmin(): void {
                 showInlineAlert('success', 'Pool closed with adjustments');
                 return reloadAfterDelay(RELOAD_DELAY_MS);
             }
+            if (target.classList.contains('pool-recalculate')) {
+                requireManageAssignments('recalculate invoice pools');
+                if (!confirm("WARNING: This will delete all existing shares and recalculate them based on current pool settings. All participants will be notified again. This action cannot be undone. Are you sure you want to proceed?")) return
+                await post(`/api/event/${getEventId()}/invoice-pools/${target.dataset.id}/recalculate`);
+                showInlineAlert('success', 'Pool recalculated successfully');
+                return reloadAfterDelay(RELOAD_DELAY_MS);
+            }
             if (target.classList.contains('surcharge-remove')) {
                 requireManageAssignments('remove surcharges');
                 await post(`/api/event/${getEventId()}/invoice-pools/${target.dataset.pool}/surcharges/${target.dataset.id}/delete`);
@@ -312,6 +319,11 @@ export function initInvoiceAdmin(): void {
         const target = e.target as HTMLElement;
         if (target.classList.contains('pool-assignment')) {
             e.preventDefault();
+            const poolStatus = (target as HTMLElement).getAttribute('data-pool-status');
+            if (poolStatus === 'CLOSED') {
+                showInlineAlert('warning', 'Pool is closed. Use the "Recalculate pool" button to apply changes.');
+                return;
+            }
             const api = (target as HTMLElement).getAttribute('data-api')!;
             const formData = new FormData(target as HTMLFormElement);
             const payload: {
@@ -330,6 +342,11 @@ export function initInvoiceAdmin(): void {
         }
         if (target.classList.contains('surcharge-form')) {
             e.preventDefault();
+            const poolStatus = (target as HTMLElement).getAttribute('data-pool-status');
+            if (poolStatus === 'CLOSED') {
+                showInlineAlert('warning', 'Pool is closed. Use the "Recalculate pool" button to apply changes.');
+                return;
+            }
             const api = (target as HTMLElement).getAttribute('data-api')!;
             const payload = Object.fromEntries(new FormData(target as HTMLFormElement).entries());
             try {

--- a/src/public/js/modules/event-participant.ts
+++ b/src/public/js/modules/event-participant.ts
@@ -5,10 +5,11 @@
 
 import type {ParticipantRow} from "../../../types/EventTypes";
 import {qs, qsAll} from '../core/dom';
-import {del, get} from '../core/http';
+import {del, get, patch} from '../core/http';
 import {formatDate} from '../core/formatting';
 import {createDietaryChip, hideSpinner, showSpinner} from '../shared/ui-helpers';
 import {showInlineAlert} from '../shared/alerts';
+import {populateDateRangeModal, submitDateRangeModal} from '../shared/date-range-modal';
 
 /**
  * Render dietary totals as colored badges
@@ -69,6 +70,8 @@ function renderRows(root: HTMLElement, data: any): void {
         tr.dataset.name = p.name.toLowerCase();
         tr.dataset.email = (p.email || '').toLowerCase();
         tr.dataset.dietary = dietary.join(',').toLowerCase();
+        tr.dataset.arrival = p.arrivalDate;
+        tr.dataset.departure = p.departureDate;
 
         const emailCell = p.email ? `<span class="d-none d-md-inline">${p.email}</span>` : '<span class="text-secondary d-none d-md-inline">—</span>';
 
@@ -78,6 +81,12 @@ function renderRows(root: HTMLElement, data: any): void {
         const allergyBtn = hasAll
             ? `<button type="button" class="btn btn-sm btn-outline-warning btn-show-allergies" data-text="${encodeURIComponent(allergiesText || '')}">
            <i class="bi bi-exclamation-triangle"></i> Details
+         </button>`
+            : '';
+
+        const editBtn = root.dataset.canUpdate === '1'
+            ? `<button type="button" class="btn btn-outline-info btn-edit-dates">
+           <i class="bi bi-calendar2-week"></i> Edit dates
          </button>`
             : '';
 
@@ -100,6 +109,7 @@ function renderRows(root: HTMLElement, data: any): void {
       <td class="text-end">
         <div class="btn-group btn-group-sm" role="group">
           ${allergyBtn}
+          ${editBtn}
           ${p.email ? `<button type="button" class="btn btn-outline-light btn-copy-email" data-email="${p.email}"><i class="bi bi-clipboard"></i> Copy email</button>` : ''}
           ${delBtn}
         </div>
@@ -173,6 +183,41 @@ async function deleteRegistration(root: HTMLElement, tr: HTMLTableRowElement): P
     }
 }
 
+function openDateModal(root: HTMLElement, tr: HTMLTableRowElement): void {
+    const modal = root.querySelector<HTMLElement>('.js-date-modal');
+    const form = root.querySelector<HTMLFormElement>('.js-date-form');
+    if (!modal || !form) return;
+
+    populateDateRangeModal({
+        modal,
+        form,
+        bounds: {min: root.dataset.startDate, max: root.dataset.endDate},
+        alertContainer: root.querySelector<HTMLElement>('#liveAlerts') || undefined,
+    }, {
+        arrivalDate: tr.dataset.arrival || '',
+        departureDate: tr.dataset.departure || '',
+        registrationId: tr.dataset.id || '',
+    });
+}
+
+async function submitDateUpdate(root: HTMLElement, form: HTMLFormElement): Promise<void> {
+    const api = root.dataset.apiUpdate;
+    const modal = root.querySelector<HTMLElement>('.js-date-modal');
+    if (!api || !modal) return;
+
+    await submitDateRangeModal({
+        modal,
+        form,
+        bounds: {min: root.dataset.startDate, max: root.dataset.endDate},
+        alertContainer: root.querySelector<HTMLElement>('#liveAlerts') || undefined,
+    }, async (payload) => {
+        await patch(`${api}/${encodeURIComponent(payload.registrationId)}`, payload);
+        await refreshList(root);
+    }, {
+        successMessage: 'Attendance dates updated',
+    });
+}
+
 /**
  * Initialize event participants module
  * Sets up list rendering, filtering, and participant operations
@@ -215,6 +260,15 @@ export function initEventParticipants(): void {
             return;
         }
 
+        const btnEdit = t.closest<HTMLButtonElement>('.btn-edit-dates');
+        if (btnEdit) {
+            ev.preventDefault();
+            const root = btnEdit.closest('.event-participants') as HTMLElement;
+            const tr = btnEdit.closest('tr') as HTMLTableRowElement;
+            openDateModal(root, tr);
+            return;
+        }
+
         const btnDel = t.closest<HTMLButtonElement>('.btn-delete-reg');
         if (btnDel) {
             ev.preventDefault();
@@ -223,5 +277,13 @@ export function initEventParticipants(): void {
             deleteRegistration(root, tr);
             return;
         }
+    });
+
+    document.addEventListener('submit', (ev) => {
+        const form = ev.target as HTMLFormElement | null;
+        if (!form?.classList.contains('js-date-form')) return;
+        ev.preventDefault();
+        const root = form.closest('.event-participants') as HTMLElement | null;
+        if (root) void submitDateUpdate(root, form);
     });
 }

--- a/src/public/js/modules/event-participant.ts
+++ b/src/public/js/modules/event-participant.ts
@@ -282,8 +282,9 @@ export function initEventParticipants(): void {
     document.addEventListener('submit', (ev) => {
         const form = ev.target as HTMLFormElement | null;
         if (!form?.classList.contains('js-date-form')) return;
-        ev.preventDefault();
         const root = form.closest('.event-participants') as HTMLElement | null;
-        if (root) void submitDateUpdate(root, form);
+        if (!root) return; // Only handle forms within event-participants component
+        ev.preventDefault();
+        void submitDateUpdate(root, form);
     });
 }

--- a/src/public/js/shared/date-range-modal.ts
+++ b/src/public/js/shared/date-range-modal.ts
@@ -1,0 +1,90 @@
+/**
+ * Helpers for reusable date range modals.
+ * Centralizes min/max handling, form population, and submit lifecycle so modules
+ * can remain lean and focused on their domain logic.
+ */
+
+import {hideSpinner, showSpinner} from './ui-helpers';
+import {showInlineAlert} from './alerts';
+
+export interface DateRangeBounds {
+    min?: string;
+    max?: string;
+}
+
+export interface DateRangeValues {
+    registrationId: string;
+    arrivalDate: string;
+    departureDate: string;
+}
+
+export interface DateRangeModalBindings {
+    modal: HTMLElement;
+    form: HTMLFormElement;
+    bounds?: DateRangeBounds;
+    alertContainer?: HTMLElement;
+}
+
+function applyBounds(form: HTMLFormElement, bounds?: DateRangeBounds): void {
+    const arrival = form.querySelector<HTMLInputElement>('input[name="arrivalDate"]');
+    const departure = form.querySelector<HTMLInputElement>('input[name="departureDate"]');
+    if (!arrival || !departure) return;
+
+    if (bounds?.min) {
+        arrival.min = bounds.min;
+        departure.min = bounds.min;
+    }
+    if (bounds?.max) {
+        arrival.max = bounds.max;
+        departure.max = bounds.max;
+    }
+}
+
+export function populateDateRangeModal(bindings: DateRangeModalBindings, values: DateRangeValues): void {
+    applyBounds(bindings.form, bindings.bounds);
+
+    const arrival = bindings.form.querySelector<HTMLInputElement>('input[name="arrivalDate"]');
+    const departure = bindings.form.querySelector<HTMLInputElement>('input[name="departureDate"]');
+    const registration = bindings.form.querySelector<HTMLInputElement>('input[name="registrationId"]');
+    if (!arrival || !departure || !registration) return;
+
+    arrival.value = values.arrivalDate;
+    departure.value = values.departureDate;
+    registration.value = values.registrationId;
+
+    (window as any).bootstrap?.Modal.getOrCreateInstance(bindings.modal)?.show();
+}
+
+export function readDateRangePayload(form: HTMLFormElement): DateRangeValues | null {
+    const arrival = form.querySelector<HTMLInputElement>('input[name="arrivalDate"]')?.value?.trim() || '';
+    const departure = form.querySelector<HTMLInputElement>('input[name="departureDate"]')?.value?.trim() || '';
+    const registrationId = form.querySelector<HTMLInputElement>('input[name="registrationId"]')?.value?.trim();
+    if (!registrationId) return null;
+    return {arrivalDate: arrival, departureDate: departure, registrationId};
+}
+
+export async function submitDateRangeModal(
+    bindings: DateRangeModalBindings,
+    submitAction: (payload: DateRangeValues) => Promise<void>,
+    options?: {
+        successMessage?: string;
+        onSuccess?: () => Promise<void> | void;
+    },
+): Promise<void> {
+    const payload = readDateRangePayload(bindings.form);
+    if (!payload) return;
+
+    const submitBtn = bindings.form.querySelector<HTMLButtonElement>('button[type="submit"]');
+    if (submitBtn) showSpinner(submitBtn);
+    try {
+        await submitAction(payload);
+        if (options?.onSuccess) await options.onSuccess();
+        showInlineAlert('success', options?.successMessage || 'Dates updated', bindings.alertContainer);
+        (window as any).bootstrap?.Modal.getOrCreateInstance(bindings.modal)?.hide();
+    } catch (err) {
+        const message = err instanceof Error ? err.message : 'Update failed.';
+        showInlineAlert('error', message, bindings.alertContainer);
+    } finally {
+        if (submitBtn) hideSpinner(submitBtn);
+    }
+}

--- a/src/public/js/shared/date-range-modal.ts
+++ b/src/public/js/shared/date-range-modal.ts
@@ -59,7 +59,7 @@ export function readDateRangePayload(form: HTMLFormElement): DateRangeValues | n
     const arrival = form.querySelector<HTMLInputElement>('input[name="arrivalDate"]')?.value?.trim() || '';
     const departure = form.querySelector<HTMLInputElement>('input[name="departureDate"]')?.value?.trim() || '';
     const registrationId = form.querySelector<HTMLInputElement>('input[name="registrationId"]')?.value?.trim();
-    if (!registrationId) return null;
+    if (!registrationId || !arrival || !departure) return null;
     return {arrivalDate: arrival, departureDate: departure, registrationId};
 }
 

--- a/src/routes/api/event.ts
+++ b/src/routes/api/event.ts
@@ -96,6 +96,15 @@ app.delete(
     })
 );
 
+app.patch(
+    '/:id/registrations/:regId',
+    requirePermissionApi(permFct, PERM.MANAGE_REGISTRATIONS),
+    asyncHandler(async (req, res) => {
+        const msg = await eventController.updateRegistrationDates(resFct(req), req.params.regId, req.body, res.locals.permData);
+        renderer.respondWithSuccessJson(res, msg);
+    })
+);
+
 // Invoice pools
 app.use('/:id/invoice-pools', buildInvoiceRouter(permFct, resFct));
 

--- a/src/routes/api/eventInvoices.ts
+++ b/src/routes/api/eventInvoices.ts
@@ -121,7 +121,16 @@ export function buildInvoiceRouter(permFct: (req: Request) => any, resFct: (req:
         '/:poolId/invoices/:invoiceId/close',
         requirePermissionApi(permFct, PERM.MANAGE_ASSIGNMENTS),
         asyncHandler(async (req, res) => {
-            await eventPoolController.closeInvoice(resFct(req), req.params.poolId, req.params.invoiceId, req.session);
+            await eventPoolController.closeInvoice(resFct(req), req.params.poolId, req.params.invoiceId, req.session, res.locals.permData);
+            renderer.respondWithSuccessJson(res, "closed");
+        })
+    );
+
+    router.post(
+        '/:poolId/invoices/:invoiceId/close-self',
+        requireEventParticipantAPI(resFct),
+        asyncHandler(async (req, res) => {
+            await eventPoolController.closeInvoice(resFct(req), req.params.poolId, req.params.invoiceId, req.session, res.locals.permData, false);
             renderer.respondWithSuccessJson(res, "closed");
         })
     );

--- a/src/routes/api/eventInvoices.ts
+++ b/src/routes/api/eventInvoices.ts
@@ -154,6 +154,15 @@ export function buildInvoiceRouter(permFct: (req: Request) => any, resFct: (req:
     );
 
     router.post(
+        '/:poolId/recalculate',
+        requirePermissionApi(permFct, PERM.MANAGE_ASSIGNMENTS),
+        asyncHandler(async (req, res) => {
+            await eventPoolController.recalculatePool(resFct(req), req.params.poolId, req.body, req.session);
+            renderer.respondWithSuccessJson(res, "pool recalculated");
+        })
+    );
+
+    router.post(
         '/:poolId/shares/:shareId/pay',
         requirePermissionApi(permFct, PERM.MANAGE_ASSIGNMENTS),
         asyncHandler(async (req, res) => {

--- a/src/views/event/event-dashboard.pug
+++ b/src/views/event/event-dashboard.pug
@@ -144,10 +144,14 @@ block content
 
     if permData.entity.has('ACCESS_PARTICIPANTS')
         - const apiDelete = permData.entity.has('MANAGE_REGISTRATIONS') ? `/api/event/${ev.id}/registrations` : undefined
+        - const apiUpdate = permData.entity.has('MANAGE_REGISTRATIONS') ? `/api/event/${ev.id}/registrations` : undefined
         +eventParticipants({
             eventId: ev.id,
             apiList: `/api/event/${ev.id}/participants`,
             apiDelete: apiDelete,
+            apiUpdate: apiUpdate,
+            startDate: startDate,
+            endDate: endDate,
         })
 
     .row

--- a/src/views/event/event-view.pug
+++ b/src/views/event/event-view.pug
@@ -262,6 +262,8 @@ block content
             +eventParticipants({
                 eventId: ev.id,
                 apiList: `/api/event/${ev.id}/participants`,
+                startDate: startDate,
+                endDate: endDate,
             })
 
     +takeoverModal('takeoverModal')

--- a/src/views/modules/mixins/helpers.pug
+++ b/src/views/modules/mixins/helpers.pug
@@ -1,0 +1,7 @@
+//- Shared helper functions for Pug templates
+//- These functions should remain pure (no side effects) and reusable across templates
+
+//- Format a numeric value as currency with two decimal places
+//- @param {number|string} val - The value to format
+//- @return {string} - Formatted currency string (e.g., "123.45")
+- const fmtMoney = (val) => Number(val ?? 0).toFixed(2)

--- a/src/views/modules/mixins/modal_date_range.pug
+++ b/src/views/modules/mixins/modal_date_range.pug
@@ -1,0 +1,25 @@
+//- Reusable date range modal
+//- opts: title, arrivalLabel, departureLabel, startDate, endDate, modalClass, formClass, note, submitLabel, cancelLabel
+mixin dateRangeModal(id, opts)
+    .modal.fade(class=opts.modalClass id=id tabindex="-1" aria-labelledby=`${id}-title` aria-hidden="true")
+        .modal-dialog
+            .modal-content.bg-dark.text-light.border.border-secondary
+                form(class=opts.formClass)
+                    .modal-header
+                        h5.modal-title(id=`${id}-title`) #{opts.title || 'Adjust dates'}
+                        button.btn-close.btn-close-white(type="button" data-bs-dismiss="modal" aria-label="Close")
+                    .modal-body
+                        input(type="hidden" name="registrationId")
+                        .mb-3
+                            label.form-label(for=`${id}-arrival`) #{opts.arrivalLabel || 'Arrival date'}
+                            input.form-control.text-bg-dark#`${id}-arrival`(type="date" name="arrivalDate" required min=opts.startDate max=opts.endDate)
+                        .mb-0
+                            label.form-label(for=`${id}-departure`) #{opts.departureLabel || 'Departure date'}
+                            input.form-control.text-bg-dark#`${id}-departure`(type="date" name="departureDate" required min=opts.startDate max=opts.endDate)
+                    .modal-footer.d-flex.justify-content-between
+                        small.text-secondary #{opts.note || ''}
+                        .d-flex.gap-2
+                            button.btn.btn-outline-secondary(type="button" data-bs-dismiss="modal") #{opts.cancelLabel || 'Cancel'}
+                            button.btn.btn-primary(type="submit")
+                                i.bi.bi-save.me-1
+                                | #{opts.submitLabel || 'Save'}

--- a/src/views/modules/mixins/modal_date_range.pug
+++ b/src/views/modules/mixins/modal_date_range.pug
@@ -12,10 +12,10 @@ mixin dateRangeModal(id, opts)
                         input(type="hidden" name="registrationId")
                         .mb-3
                             label.form-label(for=`${id}-arrival`) #{opts.arrivalLabel || 'Arrival date'}
-                            input.form-control.text-bg-dark#`${id}-arrival`(type="date" name="arrivalDate" required min=opts.startDate max=opts.endDate)
+                            input.form-control.text-bg-dark(id=`${id}-arrival` type="date" name="arrivalDate" required min=opts.startDate max=opts.endDate)
                         .mb-0
                             label.form-label(for=`${id}-departure`) #{opts.departureLabel || 'Departure date'}
-                            input.form-control.text-bg-dark#`${id}-departure`(type="date" name="departureDate" required min=opts.startDate max=opts.endDate)
+                            input.form-control.text-bg-dark(id=`${id}-departure` type="date" name="departureDate" required min=opts.startDate max=opts.endDate)
                     .modal-footer.d-flex.justify-content-between
                         small.text-secondary #{opts.note || ''}
                         .d-flex.gap-2

--- a/src/views/modules/module_event_participants.pug
+++ b/src/views/modules/module_event_participants.pug
@@ -2,17 +2,24 @@
 //- Collapsible admin section to display participants (dates, dietary, allergies)
 //- Params: opts = { eventId, apiList, apiDelete?: string, title?, help? }
 
+include ./mixins/modal_date_range.pug
+
 mixin eventParticipants(opts)
     - const title = opts?.title ?? 'Participants'
     - const help  = opts?.help  ?? 'Registered users and guests with their attendance window and dietary information.'
     - const accId = 'ev-part-' + Math.random().toString(36).slice(2)
     - const allowDelete = Boolean(opts?.apiDelete !== undefined)
+    - const allowUpdate = Boolean(opts?.apiUpdate !== undefined)
 
     .event-participants.text-bg-dark.border.border-secondary.rounded-2.py-1.my-2(
         data-api-list=opts.apiList
         data-event-id=opts.eventId
         data-can-delete=allowDelete ? '1' : '0'
         data-api-delete=(allowDelete ? opts.apiDelete : '')
+        data-can-update=allowUpdate ? '1' : '0'
+        data-api-update=(allowUpdate ? opts.apiUpdate : '')
+        data-start-date=opts.startDate
+        data-end-date=opts.endDate
     )
         .accordion.accordion-flush(id=accId)
             .accordion-item.bg-dark.border-secondary
@@ -69,6 +76,16 @@ mixin eventParticipants(opts)
                         button.btn-close.btn-close-white(type="button" data-bs-dismiss="modal" aria-label="Close")
                     .modal-body
                         pre.js-allergy-text.mb-0(style="white-space:pre-wrap")
+
+        +dateRangeModal(`${accId}-dates`, {
+            title: 'Adjust attendance window',
+            startDate: opts.startDate,
+            endDate: opts.endDate,
+            note: 'Keep changes within the event window.',
+            submitLabel: 'Save dates',
+            modalClass: 'js-date-modal',
+            formClass: 'js-date-form',
+        })
 
     script(type="module").
         import { initEventParticipants } from "/js/modules/event-participant.gen.js";

--- a/src/views/modules/module_invoice_pool.pug
+++ b/src/views/modules/module_invoice_pool.pug
@@ -344,7 +344,7 @@ mixin poolAssignmentsForm(ev, pool, participants)
             input.form-check-input.pool-toggle(type="checkbox" name="subtractPersonalInvoices" id=`subtract-invoices-${pool.id}` checked=!!(pool.subtractPersonalInvoices))
             label.form-check-label(for=`subtract-invoices-${pool.id}`) Deduct submitter invoices from their share
         label.form-label.mt-2(for=`assign-search-${pool.id}`) Search participants
-        input.form-control.form-control-sm.assignment-search#assign-search-${pool.id}(type="search" placeholder="Filter by name or email")
+        input.form-control.form-control-sm.assignment-search(id=`assign-search-${pool.id}` type="search" placeholder="Filter by name or email")
         label.form-label.mt-2(for=`assign-list-${pool.id}`) Limit to participants (disabled when default or assign to all)
         .assignments-list.border.border-secondary-subtle.rounded-3.p-2.bg-black.text-white.overflow-auto(style="max-height: 18rem;" id=`assign-list-${pool.id}`)
             if participants && participants.length
@@ -410,7 +410,7 @@ mixin poolSurchargeForm(ev, pool, participants)
             .col-md-2
                 label.form-label.text-secondary(for=`surcharge-subtract-${pool.id}`) Offset total
                 .form-check.form-switch
-                    input.form-check-input#surcharge-subtract-${pool.id}(type="checkbox" name="subtractFromPool" checked)
+                    input.form-check-input(id=`surcharge-subtract-${pool.id}` type="checkbox" name="subtractFromPool" checked)
                     label.form-check-label(for=`surcharge-subtract-${pool.id}`) Subtract from pool
         .d-flex.justify-content-end.mt-2
             if pool.status === 'OPEN'

--- a/src/views/modules/module_invoice_pool.pug
+++ b/src/views/modules/module_invoice_pool.pug
@@ -1,4 +1,5 @@
 //- Common invoice pool fragments reused by admin and participant pages
+- const fmtMoney = (val) => Number(val ?? 0).toFixed(2)
 //- Render the outstanding shares table with surcharge notes included for clarity.
 mixin invoiceShareTable(pool, participants, admin = false)
     if pool.shares && pool.shares.length
@@ -10,6 +11,7 @@ mixin invoiceShareTable(pool, participants, admin = false)
                     th Covers
                     th Base
                     th Extra
+                    th Invoice credit
                     th Total
                     th Notes
                     th Paid
@@ -27,6 +29,7 @@ mixin invoiceShareTable(pool, participants, admin = false)
                         td #{covered || 'Self'}
                         td #{share.baseShareAmount}
                         td #{share.extraAmount}
+                        td #{share.invoiceCreditAmount || '0.00'}
                         td #{share.shareAmount}
                         td
                             if notes.length
@@ -140,6 +143,7 @@ mixin participantInvoiceOverview(invoices, pools, eventId)
                         th Amount
                         th Status
                         th Proof
+                        th Actions
                 tbody
                     each inv in invoices
                         - const poolName = pools.find(p => p.id === inv.poolId)?.name || 'A closed pool'
@@ -149,6 +153,15 @@ mixin participantInvoiceOverview(invoices, pools, eventId)
                             td #{inv.status}
                             td
                                 +invoiceProofLink(inv, eventId, inv.poolId)
+                            td
+                                if inv.status === 'APPROVED'
+                                    button.btn.btn-sm.btn-outline-success.invoice-close-self(type="button" data-pool=inv.poolId data-id=inv.id)
+                                        i.bi.bi-check2-circle.me-1
+                                        | Close
+                                else if inv.status === 'CLOSED'
+                                    span.text-secondary.small Closed
+                                else
+                                    span.text-secondary.small Awaiting review
     else
         p.text-secondary.small.mb-0 You have not submitted any invoices yet.
 
@@ -217,6 +230,7 @@ mixin participantShareSummary(registrationId, pools)
                     th Pool
                     th Base
                     th Surcharges
+                    th Invoice credit
                     th Total
                     th Notes
                     th Status
@@ -227,6 +241,7 @@ mixin participantShareSummary(registrationId, pools)
                         td #{row.pool.name}
                         td #{row.share.baseShareAmount}
                         td #{row.share.extraAmount}
+                        td #{row.share.invoiceCreditAmount || '0.00'}
                         td #{row.share.shareAmount}
                         td
                             if notes.length
@@ -263,7 +278,7 @@ mixin poolHeaderSummary(pool)
         .d-flex.flex-column.align-items-end.me-2
             span.badge.bg-info.text-dark.mb-1 #{pool.status}
             small.text-secondary.d-block.text-uppercase.fw-semibold.small Full total
-            span.fs-5.fw-bold #{pool.totalAmount}
+            span.fs-5.fw-bold #{fmtMoney(pool.totalAmount)}
 
 //- Static stats list to keep amounts readable and reusable
 mixin poolStats(pool)
@@ -272,7 +287,7 @@ mixin poolStats(pool)
         .d-flex.justify-content-between.align-items-start.gap-3
             .flex-grow-1
                 small.text-secondary.text-uppercase.fw-semibold.mb-1.d-block Full total
-                div.fs-2.fw-bold.text-white #{pool.totalAmount}
+                div.fs-2.fw-bold.text-white #{fmtMoney(pool.totalAmount)}
                 p.text-secondary.small.mb-0 A summary of everything owed in this pool.
             .text-end
                 span.badge.bg-info.text-dark #{pool.status}
@@ -281,13 +296,16 @@ mixin poolStats(pool)
                 ul.list-unstyled.mb-0.small
                     li.mb-1
                         strong Total invoices:
-                        |  #{pool.totalAmount}
+                        |  #{fmtMoney(pool.totalAmount)}
                     li.mb-1
                         strong Open invoices:
-                        |  #{pool.openAmount}
+                        |  #{fmtMoney(pool.openAmount)}
                     li.mb-1
                         strong Assigned charges:
-                        |  #{pool.additionalAmount}
+                        |  #{fmtMoney(pool.additionalAmount)}
+                    li.mb-1
+                        strong Surcharges reducing pool:
+                        |  #{fmtMoney(pool.surchargeOffsetAmount)}
                     li.mb-1
                         strong Distribution mode:
                         if pool.distributionMethod === "EQUAL"
@@ -298,10 +316,16 @@ mixin poolStats(pool)
                 ul.list-unstyled.mb-0.small
                     li.mb-1
                         strong Distributable total:
-                        |  #{pool.payableAmount}
+                        |  #{fmtMoney(pool.payableAmount)}
                     li.mb-1
                         strong Outstanding payments:
-                        |  #{pool.outstandingAmount}
+                        |  #{fmtMoney(pool.outstandingAmount)}
+                    li.mb-1
+                        strong Credits owed to participants:
+                        |  #{fmtMoney(pool.creditAmount)}
+                    li.mb-1
+                        strong Deduct submitter invoices:
+                        |  #{pool.subtractPersonalInvoices ? 'Enabled' : 'Disabled'}
                     li.mb-1
                         strong Assigned to:
                         |  #{pool.assignAll ? 'All participants' : assignments.length}
@@ -316,14 +340,24 @@ mixin poolAssignmentsForm(ev, pool, participants)
         .form-check
             input.form-check-input.pool-toggle(type="checkbox" name="isDefault" id=`default-${pool.id}` checked=!!(pool.isDefault))
             label.form-check-label(for=`default-${pool.id}`) Default for new participants
+        .form-check
+            input.form-check-input.pool-toggle(type="checkbox" name="subtractPersonalInvoices" id=`subtract-invoices-${pool.id}` checked=!!(pool.subtractPersonalInvoices))
+            label.form-check-label(for=`subtract-invoices-${pool.id}`) Deduct submitter invoices from their share
+        label.form-label.mt-2(for=`assign-search-${pool.id}`) Search participants
+        input.form-control.form-control-sm.assignment-search#assign-search-${pool.id}(type="search" placeholder="Filter by name or email")
         label.form-label.mt-2(for=`assign-list-${pool.id}`) Limit to participants (disabled when default or assign to all)
-        .assignments-list.border.border-secondary-subtle.rounded-3.p-2.bg-black.text-white(id=`assign-list-${pool.id}`)
+        .assignments-list.border.border-secondary-subtle.rounded-3.p-2.bg-black.text-white.overflow-auto(style="max-height: 18rem;" id=`assign-list-${pool.id}`)
             if participants && participants.length
                 each p in participants
-                    - const selected = pool.assignments?.some(a => a.registration?.id === p.id)
-                    .form-check
-                        input.form-check-input(type="checkbox" name="registrations" value=p.id id=`pool-${pool.id}-reg-${p.id}` checked=selected disabled=!!(pool.assignAll || pool.isDefault))
-                        label.form-check-label(for=`pool-${pool.id}-reg-${p.id}`)= `${p.name} (${p.email})`
+                    - const selected = pool.assignAll || pool.isDefault || (pool.assignments || []).some(a => (a.registrationId || a.registration?.id) === p.id)
+                    - const exempt = (pool.assignments || []).some(a => (a.registrationId || a.registration?.id) === p.id && a.isExempt)
+                    .d-flex.justify-content-between.align-items-center.gap-2.py-1.px-2.rounded-2(data-search-text=`${(p.name || '').toLowerCase()} ${String(p.email || '').toLowerCase()}`)
+                        .form-check.mb-0
+                            input.form-check-input(type="checkbox" name="registrations" value=p.id id=`pool-${pool.id}-reg-${p.id}` checked=selected disabled=!!(pool.assignAll || pool.isDefault))
+                            label.form-check-label(for=`pool-${pool.id}-reg-${p.id}`)= `${p.name} (${p.email})`
+                        .form-check.form-switch.mb-0
+                            input.form-check-input(type="checkbox" name="exemptions" value=p.id id=`pool-${pool.id}-exempt-${p.id}` checked=exempt)
+                            label.form-check-label(for=`pool-${pool.id}-exempt-${p.id}`) Exempt
             else
                 p.text-secondary.small.mb-0 No participants yet.
         button.btn.btn-outline-light.btn-sm.mt-2(type="submit")
@@ -341,6 +375,10 @@ mixin poolSurchargeList(pool, participants)
                     .flex-grow-1.me-2
                         strong.me-2 #{partName || `Participant #${surcharge.registrationId}`}
                         span.badge.bg-secondary #{surcharge.amount}
+                        if surcharge.subtractFromPool
+                            span.badge.bg-info.text-dark.ms-2 Offsets pool total
+                        else
+                            span.badge.bg-warning.text-dark.ms-2 Extra charge only
                         p.mb-0.text-secondary.small #{surcharge.note}
                     button.btn.btn-outline-danger.btn-sm.surcharge-remove(type="button" data-pool=pool.id data-id=surcharge.id)
                         i.bi.bi-x-lg
@@ -361,9 +399,14 @@ mixin poolSurchargeForm(ev, pool, participants)
             .col-md-3
                 label.form-label.text-secondary(for=`surcharge-amount-${pool.id}`) Amount
                 input.form-control.text-bg-dark(type="number" name="amount" min="0.01" step="0.01" required)
-            .col-md-5
+            .col-md-3
                 label.form-label.text-secondary(for=`surcharge-note-${pool.id}`) Note
                 input.form-control.text-bg-dark(type="text" name="note" required placeholder="Reason for surcharge")
+            .col-md-2
+                label.form-label.text-secondary(for=`surcharge-subtract-${pool.id}`) Offset total
+                .form-check.form-switch
+                    input.form-check-input#surcharge-subtract-${pool.id}(type="checkbox" name="subtractFromPool" checked)
+                    label.form-check-label(for=`surcharge-subtract-${pool.id}`) Subtract from pool
         .d-flex.justify-content-end.mt-2
             button.btn.btn-outline-light.btn-sm(type="submit")
                 i.bi.bi-plus-circle.me-1
@@ -374,8 +417,7 @@ mixin poolAdjustmentSection(ev, pool, participants)
     .mt-3
         h6.mb-2 Manual surcharge assignment (do before closing)
         p.text-secondary.small.mb-2
-            |  Add surcharges with notes before closing.&nbsp;
-            strong Surcharges will be subtracted from the total distributed among all participants.
+            |  Add surcharges with notes before closing and choose whether they reduce the shared pool or only apply to the participant.
             |  These amounts are paid only by the participant or their covering payer in addition to the automatically calculated share.
         +poolSurchargeList(pool, participants)
         +poolSurchargeForm(ev, pool, participants)
@@ -421,7 +463,7 @@ mixin poolManagementSection(ev, pool, participants)
                             |  This means that after that, you will not be able to make any changes to the pool except tracking which share was paid.
                         p.text-secondary.small.mb-2
                             strong  Manually applied surcharges will reduce the open invoice amount to be distributed.
-                            |  This is useful e.g. for making sure that consumables contained in this pool like drinks, which should not be paid for by all participants, are correctly distributed.
+                            |  Only surcharges marked to offset the pool total will reduce the shared cost; others are added on top of the payer's share.
                         p.text-secondary.small.mb-2
                             strong  Check and adjust the participant attendance periods before closing the pool when using the "Days Attended" distribution mode.
                         .d-flex.justify-content-between.align-items-end.flex-wrap.gap-2.mb-3
@@ -470,6 +512,9 @@ mixin invoicePoolCreateModal(ev, participants)
                                     input#defaultPool.form-check-input.pool-toggle(type="checkbox" name="isDefault")
                                     label.form-check-label(for="defaultPool") Make this the default pool
                                 small.text-secondary Default pools automatically include future participants without reopening assignments.
+                                .form-check.mt-2
+                                    input#subtractPersonalInvoicesCreate.form-check-input(type="checkbox" name="subtractPersonalInvoices" checked)
+                                    label.form-check-label(for="subtractPersonalInvoicesCreate") Deduct submitter invoices from their share
                             .col-12
                                 label.form-label(for="poolRegistrations") Limit to participants (disabled when default or assign to all)
                                 .assignments-list.border.border-secondary-subtle.rounded-3.p-2.bg-black.text-white#poolRegistrations

--- a/src/views/modules/module_invoice_pool.pug
+++ b/src/views/modules/module_invoice_pool.pug
@@ -1,5 +1,5 @@
 //- Common invoice pool fragments reused by admin and participant pages
-- const fmtMoney = (val) => Number(val ?? 0).toFixed(2)
+include mixins/helpers.pug
 //- Render the outstanding shares table with surcharge notes included for clarity.
 mixin invoiceShareTable(pool, participants, admin = false)
     if pool.shares && pool.shares.length
@@ -332,7 +332,7 @@ mixin poolStats(pool)
 
 //- Assignment form kept separate so both admin tabs and future reuse can pull it in
 mixin poolAssignmentsForm(ev, pool, participants)
-    form.pool-assignment(data-api=`/api/event/${ev.id}/invoice-pools/${pool.id}/assignments`)
+    form.pool-assignment(data-api=`/api/event/${ev.id}/invoice-pools/${pool.id}/assignments` data-pool-status=pool.status)
         label.form-label.text-secondary.mb-1 Update assignment
         .form-check
             input.form-check-input.pool-toggle(type="checkbox" name="assignAll" id=`assign-${pool.id}` checked=!!(pool.assignAll))
@@ -351,7 +351,7 @@ mixin poolAssignmentsForm(ev, pool, participants)
                 each p in participants
                     - const selected = pool.assignAll || pool.isDefault || (pool.assignments || []).some(a => (a.registrationId || a.registration?.id) === p.id)
                     - const exempt = (pool.assignments || []).some(a => (a.registrationId || a.registration?.id) === p.id && a.isExempt)
-                    .d-flex.justify-content-between.align-items-center.gap-2.py-1.px-2.rounded-2(data-search-text=`${(p.name || '').toLowerCase()} ${String(p.email || '').toLowerCase()}`)
+                    .d-flex.justify-content-between.align-items-center.gap-2.py-1.px-2.rounded-2(data-search-text=`${String(p.name || '').toLowerCase()} ${String(p.email || '').toLowerCase()}`)
                         .form-check.mb-0
                             input.form-check-input(type="checkbox" name="registrations" value=p.id id=`pool-${pool.id}-reg-${p.id}` checked=selected disabled=!!(pool.assignAll || pool.isDefault))
                             label.form-check-label(for=`pool-${pool.id}-reg-${p.id}`)= `${p.name} (${p.email})`
@@ -360,9 +360,14 @@ mixin poolAssignmentsForm(ev, pool, participants)
                             label.form-check-label(for=`pool-${pool.id}-exempt-${p.id}`) Exempt
             else
                 p.text-secondary.small.mb-0 No participants yet.
-        button.btn.btn-outline-light.btn-sm.mt-2(type="submit")
-            i.bi.bi-save.me-1
-            | Save assignments
+        if pool.status === 'OPEN'
+            button.btn.btn-outline-light.btn-sm.mt-2(type="submit")
+                i.bi.bi-save.me-1
+                | Save assignments
+        else
+            p.text-warning.small.mt-2.mb-0
+                i.bi.bi-info-circle.me-1
+                | Changes will only be applied when you click "Recalculate pool" below
 
 //- Render surcharges grouped per participant so admins see what will be charged
 mixin poolSurchargeList(pool, participants)
@@ -388,7 +393,7 @@ mixin poolSurchargeList(pool, participants)
 
 //- Form to add a new surcharge before closing a pool
 mixin poolSurchargeForm(ev, pool, participants)
-    form.surcharge-form(data-api=`/api/event/${ev.id}/invoice-pools/${pool.id}/surcharges`)
+    form.surcharge-form(data-api=`/api/event/${ev.id}/invoice-pools/${pool.id}/surcharges` data-pool-status=pool.status)
         .row.g-2.align-items-end
             .col-md-4
                 label.form-label.text-secondary(for=`surcharge-target-${pool.id}`) Participant
@@ -408,9 +413,14 @@ mixin poolSurchargeForm(ev, pool, participants)
                     input.form-check-input#surcharge-subtract-${pool.id}(type="checkbox" name="subtractFromPool" checked)
                     label.form-check-label(for=`surcharge-subtract-${pool.id}`) Subtract from pool
         .d-flex.justify-content-end.mt-2
-            button.btn.btn-outline-light.btn-sm(type="submit")
-                i.bi.bi-plus-circle.me-1
-                | Add surcharge
+            if pool.status === 'OPEN'
+                button.btn.btn-outline-light.btn-sm(type="submit")
+                    i.bi.bi-plus-circle.me-1
+                    | Add surcharge
+            else
+                p.text-warning.small.mb-0
+                    i.bi.bi-info-circle.me-1
+                    | Changes will only be applied when you click "Recalculate pool" below
 
 //- Charges and takeovers configured before closing a pool
 mixin poolAdjustmentSection(ev, pool, participants)
@@ -443,12 +453,11 @@ mixin poolManagementSection(ev, pool, participants)
                     .col-md-4
                         +poolStats(pool)
                     .col-md-8
-                        if pool.status === 'OPEN'
-                            +poolAssignmentsForm(ev, pool, participants)
-                        else
-                            +poolShareSection(pool, participants)
-                if pool.status === 'OPEN'
-                    +poolAdjustmentSection(ev, pool, participants)
+                        +poolAssignmentsForm(ev, pool, participants)
+                        if pool.status === 'CLOSED'
+                            .mt-3
+                                +poolShareSection(pool, participants)
+                +poolAdjustmentSection(ev, pool, participants)
                 +invoiceOverview('admin', {pool: pool, participants: participants, eventId: ev.id})
                 if pool.status === 'OPEN'
                     .row.mt-2.border.border-secondary-subtle.rounded-2.pt-2
@@ -470,6 +479,21 @@ mixin poolManagementSection(ev, pool, participants)
                             button.btn.btn-sm.btn-warning.pool-close(type="button" data-id=pool.id)
                                 i.bi.bi-x-circle.me-1
                                 | Close pool
+                else if pool.status === 'CLOSED'
+                    .row.mt-2.border.border-danger.rounded-2.pt-2
+                        h6.text-danger
+                            i.bi.bi-exclamation-triangle-fill.me-1
+                            |  Danger zone
+                        p.small.mb-2
+                            strong Recalculating a closed pool will delete all existing shares and recalculate them based on current pool settings.
+                            |  This action cannot be undone. Make sure all pool settings (assignments, surcharges, takeovers) are correct before proceeding.
+                        p.text-secondary.small.mb-2
+                            strong Warning: This will notify all participants again with updated share amounts.
+                            |  Only use this if you need to adjust pool settings after closure.
+                        .d-flex.justify-content-between.align-items-end.flex-wrap.gap-2.mb-3
+                            button.btn.btn-sm.btn-danger.pool-recalculate(type="button" data-id=pool.id)
+                                i.bi.bi-arrow-clockwise.me-1
+                                | Recalculate pool
 
 //- Management tab content for the admin dashboard
 mixin invoicePoolManageTab(ev, pools, participants)

--- a/tests/controller/event.controller.test.ts
+++ b/tests/controller/event.controller.test.ts
@@ -20,6 +20,7 @@ jest.mock('../../src/modules/database/services/EventService', () => ({
     updateEventTitle: jest.fn(),
     updateEventDescription: jest.fn(),
     updateEventDates: jest.fn(),
+    updateRegistrationDates: jest.fn(),
 }));
 
 jest.mock('../../src/modules/database/services/EventInvoiceService', () => ({
@@ -263,6 +264,44 @@ describe('updateEventSettings', () => {
                 if (expectNotCalled) {
                     expectNotCalled.forEach(serviceName => {
                         expect(eventService[serviceName]).not.toHaveBeenCalled();
+                    });
+                }
+            }
+        }
+    );
+});
+
+describe('updateRegistrationDates', () => {
+    const {updateRegistrationDates} = controller as any;
+    
+    test.each(testData.updateRegistrationDatesData)(
+        '$description',
+        async ({body, event, registrationId, expectedMessage, expectedCalls, expectNotCalled, shouldThrow, datesOutsideWindow}: any) => {
+            const mockEvent = {id: 'e1', ...event} as any;
+            
+            // Set up isWithinWindow mock based on test expectations
+            (isWithinWindow as jest.Mock).mockReturnValue(!datesOutsideWindow);
+            
+            if (shouldThrow) {
+                await expect(
+                    updateRegistrationDates(mockEvent, registrationId, body)
+                ).rejects.toThrow(shouldThrow === 'APIError' ? APIError : Error);
+                
+                if (expectNotCalled) {
+                    expectNotCalled.forEach(serviceName => {
+                        expect(eventService[serviceName]).not.toHaveBeenCalled();
+                    });
+                }
+            } else {
+                const msg = await updateRegistrationDates(mockEvent, registrationId, body);
+                
+                if (expectedMessage) {
+                    verifyResult(msg, expectedMessage);
+                }
+                
+                if (expectedCalls) {
+                    Object.keys(expectedCalls).forEach(serviceName => {
+                        verifyMockCall(eventService[serviceName], ...expectedCalls[serviceName]);
                     });
                 }
             }

--- a/tests/controller/eventPool.controller.test.ts
+++ b/tests/controller/eventPool.controller.test.ts
@@ -2,6 +2,16 @@
  * Controller unit tests for eventPoolController (services mocked).
  */
 
+// Mock the database connection to avoid TypeORM initialization issues
+jest.mock('../../src/modules/database/dataSource', () => ({
+    AppDataSource: {
+        getRepository: jest.fn(),
+        transaction: jest.fn(),
+        query: jest.fn(),
+    },
+    initDataSource: jest.fn(),
+}));
+
 jest.mock('../../src/modules/database/services/EventService', () => ({
     getRegistrationFor: jest.fn(),
     getRegistrationsForEvent: jest.fn(),
@@ -18,6 +28,7 @@ jest.mock('../../src/modules/database/services/EventInvoiceService', () => ({
     declineInvoice: jest.fn(),
     closeInvoice: jest.fn(),
     closePool: jest.fn(),
+    reopenPool: jest.fn(),
     clearInvoiceProofs: jest.fn(),
     markPaid: jest.fn(),
 }));
@@ -44,11 +55,18 @@ jest.mock('../../src/modules/email', () => ({
     send: jest.fn(),
 }));
 
+// Mock EventInvoicePool entity to prevent TypeORM initialization
+jest.mock('../../src/modules/database/entities/event/EventInvoicePool', () => ({
+    EventInvoicePool: class EventInvoicePool {},
+    InvoicePoolDistributions: ['EQUAL', 'TIME_BASED'],
+}));
+
 import {purgeExpiredProofs} from '../../src/controller/eventPoolController';
 import * as eventService from '../../src/modules/database/services/EventService';
 import * as invoiceService from '../../src/modules/database/services/EventInvoiceService';
 import {setupMock, verifyMockCall} from '../keywords/common/controllerKeywords';
 import * as testData from '../data/controller/eventPoolData';
+import {APIError} from '../../src/modules/lib/errors';
 
 beforeEach(() => {
     jest.clearAllMocks();

--- a/tests/controller/eventPool.controller.test.ts
+++ b/tests/controller/eventPool.controller.test.ts
@@ -66,7 +66,6 @@ import * as eventService from '../../src/modules/database/services/EventService'
 import * as invoiceService from '../../src/modules/database/services/EventInvoiceService';
 import {setupMock, verifyMockCall} from '../keywords/common/controllerKeywords';
 import * as testData from '../data/controller/eventPoolData';
-import {APIError} from '../../src/modules/lib/errors';
 
 beforeEach(() => {
     jest.clearAllMocks();

--- a/tests/data/controller/eventData.ts
+++ b/tests/data/controller/eventData.ts
@@ -337,3 +337,64 @@ export const updateEventSettingsData = {
         },
     ],
 };
+
+export const updateRegistrationDatesData = [
+    {
+        description: 'updates registration dates with valid data',
+        body: {
+            arrivalDate: '2025-06-02',
+            departureDate: '2025-06-04',
+        },
+        event: {
+            startDate: '2025-06-01',
+            endDate: '2025-06-05',
+        },
+        registrationId: '1',
+        expectedMessage: 'Registration updated',
+        expectedCalls: {
+            updateRegistrationDates: ['e1', 1, '2025-06-02', '2025-06-04'],
+        },
+    },
+    {
+        description: 'rejects dates outside event window',
+        body: {
+            arrivalDate: '2025-05-31',
+            departureDate: '2025-06-04',
+        },
+        event: {
+            startDate: '2025-06-01',
+            endDate: '2025-06-05',
+        },
+        registrationId: '1',
+        shouldThrow: 'APIError',
+        expectNotCalled: ['updateRegistrationDates'],
+        datesOutsideWindow: true,
+    },
+    {
+        description: 'rejects invalid date format',
+        body: {
+            arrivalDate: 'invalid-date',
+            departureDate: '2025-06-04',
+        },
+        event: {
+            startDate: '2025-06-01',
+            endDate: '2025-06-05',
+        },
+        registrationId: '1',
+        shouldThrow: 'APIError',
+        expectNotCalled: ['updateRegistrationDates'],
+    },
+    {
+        description: 'rejects missing dates',
+        body: {
+            arrivalDate: '2025-06-02',
+        },
+        event: {
+            startDate: '2025-06-01',
+            endDate: '2025-06-05',
+        },
+        registrationId: '1',
+        shouldThrow: 'APIError',
+        expectNotCalled: ['updateRegistrationDates'],
+    },
+];

--- a/tests/data/controller/eventPoolData.ts
+++ b/tests/data/controller/eventPoolData.ts
@@ -157,3 +157,66 @@ export const proofCleanupData = [
         shouldCleanup: false,
     },
 ];
+
+export const closeInvoiceData = [
+    {
+        description: 'submitter can close their own approved invoice',
+        invoice: {
+            id: 1,
+            status: 'APPROVED',
+            registration: {id: 5},
+        },
+        actorRegId: 5,
+        permData: {entity: new Map()},
+        allowManageOverride: true,
+        expectedSuccess: true,
+    },
+    {
+        description: 'admin can close any invoice',
+        invoice: {
+            id: 2,
+            status: 'APPROVED',
+            registration: {id: 10},
+        },
+        actorRegId: 5,
+        permData: {entity: new Map([['MANAGE_ASSIGNMENTS', true]])},
+        allowManageOverride: true,
+        expectedSuccess: true,
+    },
+    {
+        description: 'submitter cannot close unapproved invoice',
+        invoice: {
+            id: 3,
+            status: 'NEW',
+            registration: {id: 5},
+        },
+        actorRegId: 5,
+        permData: {entity: new Map()},
+        allowManageOverride: true,
+        shouldThrow: 'Invoices must be approved before closing',
+    },
+    {
+        description: 'non-submitter cannot close others invoice without admin',
+        invoice: {
+            id: 4,
+            status: 'APPROVED',
+            registration: {id: 10},
+        },
+        actorRegId: 5,
+        permData: {entity: new Map()},
+        allowManageOverride: true,
+        shouldThrow: 'You can only close your own approved invoices, unless you are an administrator.',
+    },
+    {
+        description: 'admin can close unapproved invoice',
+        invoice: {
+            id: 5,
+            status: 'NEW',
+            registration: {id: 10},
+        },
+        actorRegId: 5,
+        permData: {entity: new Map([['MANAGE_ASSIGNMENTS', true]])},
+        allowManageOverride: true,
+        expectedSuccess: true,
+    },
+];

--- a/tests/data/database/eventServiceData.ts
+++ b/tests/data/database/eventServiceData.ts
@@ -303,3 +303,63 @@ export const eventRegistrationCheckData = [
         },
     },
 ];
+
+export const updateRegistrationDatesData = [
+    {
+        description: 'updates registration dates successfully',
+        event: {
+            ownerId: 1,
+            title: 'Date Update Event',
+            description: null,
+            startDate: '2025-11-01',
+            endDate: '2025-11-05',
+            location: null,
+            bindingDeadline: null,
+            requireDietaryInfo: false,
+            maxParticipants: null,
+            timezone: null,
+        },
+        user: {
+            id: 5,
+            username: 'u5',
+            name: 'User Five',
+            email: 'u5@example.com',
+        },
+        initialRegistration: {
+            userId: 5,
+            arrivalDate: '2025-11-01',
+            departureDate: '2025-11-03',
+        },
+        update: {
+            arrivalDate: '2025-11-02',
+            departureDate: '2025-11-05',
+        },
+        expected: {
+            arrivalDate: '2025-11-02',
+            departureDate: '2025-11-05',
+        },
+    },
+    {
+        description: 'throws error for non-existent registration',
+        event: {
+            ownerId: 1,
+            title: 'Missing Reg Event',
+            description: null,
+            startDate: '2025-11-01',
+            endDate: '2025-11-05',
+            location: null,
+            bindingDeadline: null,
+            requireDietaryInfo: false,
+            maxParticipants: null,
+            timezone: null,
+        },
+        update: {
+            nonExistentRegId: 99999,
+            arrivalDate: '2025-11-02',
+            departureDate: '2025-11-04',
+        },
+        expected: {
+            error: 'Registration not found',
+        },
+    },
+];

--- a/tests/database/event.service.test.ts
+++ b/tests/database/event.service.test.ts
@@ -26,6 +26,7 @@ import {
     updateEventDescription,
     updateEventMeta,
     updateEventTitle,
+    updateRegistrationDates,
 } from '../../src/modules/database/services/EventService';
 
 import {AppDataSource, initDataSource} from '../../src/modules/database/dataSource';
@@ -45,6 +46,7 @@ import {
     registeredEventsData,
     eventFullData,
     eventRegistrationCheckData,
+    updateRegistrationDatesData,
 } from '../data/database/eventServiceData';
 
 // Helper to clear relevant tables between tests (order matters due to FKs)
@@ -360,5 +362,57 @@ describe('eventService (mysql)', () => {
 
         await registerGuest(eid, testCase.registrations.guest.guestId, testCase.registrations.guest.arrivalDate, testCase.registrations.guest.departureDate, null, null);
         expect(await isRegisteredForEvent({guestId: testCase.principals.guest.id}, eid)).toBe(testCase.expected.guestAfterRegistration);
+    });
+
+    test.each(updateRegistrationDatesData)('$description', async (testCase) => {
+        if (testCase.expected.error) {
+            // Test error case - non-existent registration
+            const eid = await createEventTx(
+                testCase.event.ownerId,
+                testCase.event.title,
+                testCase.event.description,
+                testCase.event.startDate,
+                testCase.event.endDate,
+                testCase.event.location,
+                testCase.event.bindingDeadline,
+                testCase.event.requireDietaryInfo,
+                testCase.event.maxParticipants,
+                testCase.event.timezone
+            );
+            await expect(updateRegistrationDates(eid, testCase.update.nonExistentRegId, testCase.update.arrivalDate, testCase.update.departureDate))
+                .rejects.toThrow(testCase.expected.error);
+        } else {
+            // Test successful update
+            const user = AppDataSource.getRepository(User).create(testCase.user);
+            await AppDataSource.getRepository(User).save(user);
+
+            const eid = await createEventTx(
+                testCase.event.ownerId,
+                testCase.event.title,
+                testCase.event.description,
+                testCase.event.startDate,
+                testCase.event.endDate,
+                testCase.event.location,
+                testCase.event.bindingDeadline,
+                testCase.event.requireDietaryInfo,
+                testCase.event.maxParticipants,
+                testCase.event.timezone
+            );
+
+            const regId = await registerUser(
+                eid,
+                testCase.initialRegistration.userId,
+                testCase.initialRegistration.arrivalDate,
+                testCase.initialRegistration.departureDate,
+                null,
+                null
+            );
+
+            await updateRegistrationDates(eid, regId, testCase.update.arrivalDate, testCase.update.departureDate);
+
+            const updated = await getRegistrationFor({userId: testCase.user.id}, eid);
+            expect(updated?.arrivalDate).toBe(testCase.expected.arrivalDate);
+            expect(updated?.departureDate).toBe(testCase.expected.departureDate);
+        }
     });
 });


### PR DESCRIPTION
## Summary
- allow participant invoice credits to exceed their own pool charges and pass numeric share amounts into persistence
- store invoice share amounts with currency transformers so values remain numeric in code while formatting to two decimals in the database
- extract a reusable date-range modal mixin and helper, wiring event participant attendance edits to the shared components

## Testing
- `npm test -- --runInBand --testPathPattern=event` *(fails: npm is not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932e6fc02888332b6abc17fe01ca779)