### PR TITLE
Ensure pool recalculation applies pending pool changes

### DIFF
--- a/src/controller/eventPoolController.ts
+++ b/src/controller/eventPoolController.ts
@@ -96,9 +96,9 @@ async function createInvoicePool(event: Event, body: any) {
 }
 
 // Update pool assignments before closure, respecting default/assign-all toggles and allowed participants.
-async function updatePoolAssignments(event: Event, poolId: string, body: any) {
+async function updatePoolAssignments(event: Event, poolId: string, body: any, allowClosed = false) {
     const pool = await ensurePool(event, poolId);
-    if (pool.status === 'CLOSED') throw new APIError('Pool is closed', body, 400);
+    if (pool.status === 'CLOSED' && !allowClosed) throw new APIError('Pool is closed', body, 400);
     const isDefault = body.isDefault === true || body.isDefault === 'on';
     const assignAll = body.assignAll === true || body.assignAll === 'on';
     const subtractPersonalInvoices = body.subtractPersonalInvoices === undefined
@@ -113,9 +113,9 @@ async function updatePoolAssignments(event: Event, poolId: string, body: any) {
 }
 
 // Create a participant-specific surcharge that will be factored in during pool closure.
-async function addPoolSurcharge(event: Event, poolId: string, body: any) {
+async function addPoolSurcharge(event: Event, poolId: string, body: any, allowClosed = false) {
     const pool = await ensurePool(event, poolId);
-    if (pool.status === 'CLOSED') throw new APIError('Pool is closed', body, 400);
+    if (pool.status === 'CLOSED' && !allowClosed) throw new APIError('Pool is closed', body, 400);
     const schema = Joi.object({
         registrationId: Joi.number().integer().required(),
         amount: Joi.number().positive().required(),
@@ -562,6 +562,15 @@ async function recalculatePool(event: Event, poolId: string, body: any = {}, ses
     }
 
     try {
+        // Persist any pending assignment or surcharge updates submitted with the recalculation request
+        if (body.assignments) {
+            await updatePoolAssignments(event, poolId, body.assignments, true);
+        }
+
+        if (body.surcharge) {
+            await addPoolSurcharge(event, poolId, body.surcharge, true);
+        }
+
         // Reopen the pool (uses SERIALIZABLE transaction with pessimistic write lock)
         await invoiceService.reopenPool(poolId);
         

--- a/src/public/js/events.ts
+++ b/src/public/js/events.ts
@@ -298,7 +298,30 @@ export function initInvoiceAdmin(): void {
             if (target.classList.contains('pool-recalculate')) {
                 requireManageAssignments('recalculate invoice pools');
                 if (!confirm("WARNING: This will delete all existing shares and recalculate them based on current pool settings. All participants will be notified again. This action cannot be undone. Are you sure you want to proceed?")) return;
-                await post(`/api/event/${getEventId()}/invoice-pools/${target.dataset.id}/recalculate`);
+                const poolRoot = target.closest('.invoice-pool');
+                const payload: Record<string, unknown> = {};
+
+                const assignmentForm = poolRoot?.querySelector('form.pool-assignment') as HTMLFormElement | null;
+                if (assignmentForm) {
+                    const formData = new FormData(assignmentForm);
+                    const assignments: Record<string, FormDataEntryValue | FormDataEntryValue[]> = Object.fromEntries(formData.entries());
+                    assignments.registrations = formData.getAll('registrations');
+                    assignments.exemptions = formData.getAll('exemptions');
+                    payload.assignments = assignments;
+                }
+
+                const surchargeForm = poolRoot?.querySelector('form.surcharge-form') as HTMLFormElement | null;
+                if (surchargeForm) {
+                    const formData = new FormData(surchargeForm);
+                    const registrationId = formData.get('registrationId');
+                    const amount = formData.get('amount');
+                    const note = formData.get('note');
+                    if (registrationId && amount && note) {
+                        payload.surcharge = Object.fromEntries(formData.entries());
+                    }
+                }
+
+                await post(`/api/event/${getEventId()}/invoice-pools/${target.dataset.id}/recalculate`, payload);
                 showInlineAlert('success', 'Pool recalculated successfully');
                 return reloadAfterDelay(RELOAD_DELAY_MS);
             }


### PR DESCRIPTION
## Summary
- allow recalculation requests to persist assignment and surcharge updates even when a pool is closed
- send assignment and surcharge form data with the recalc action so server-side recalculation uses the latest settings

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693323cfccb88332be2fcce0bb99a59a)