### PR TITLE
Allow slot pencil edits with description permission

### DIFF
--- a/docs/user-guide/PACKING_LISTS.md
+++ b/docs/user-guide/PACKING_LISTS.md
@@ -88,7 +88,7 @@ When assigned count reaches max:
 
 Depending on permissions granted:
 - **Double-click Title** to edit item name (requires EDIT_TITLE or ITEM_EDIT permission)
-- **Double-click Description** to edit details (requires EDIT_DESC or ITEM_EDIT permission)
+- **Double-click Description** to edit details (requires EDIT_DESC on the item, ITEM_EDIT on the list, or ITEM_EDIT_DESC on the list)
 - **Double-click Max number** to change quantity needed (requires EDIT_CAPACITY or ITEM_EDIT permission)
 - Changes save automatically
 

--- a/docs/user-guide/PERMISSIONS.md
+++ b/docs/user-guide/PERMISSIONS.md
@@ -76,6 +76,7 @@ The system uses these permission bits (can be combined):
 ### Item Permissions
 - **ITEM_ADD** - Can add new items (slots, packing items, drivers, etc.)
 - **ITEM_EDIT** - Can edit existing items
+- **ITEM_EDIT_DESC** - Can edit the description of every item in the entity
 - **ITEM_DELETE** - Can delete items
 
 ### Management Permissions
@@ -111,7 +112,7 @@ If you have MANAGE_PERMISSIONS permission:
 The system offers preset combinations:
 
 - **FULL_EDIT**: All edit permissions (EDIT_TITLE, EDIT_DESC, EDIT_CAPACITY, EDIT_META)
-- **FULL_ITEM**: All item permissions (ITEM_ADD, ITEM_EDIT, ITEM_DELETE)
+- **FULL_ITEM**: All item permissions (ITEM_ADD, ITEM_EDIT, ITEM_EDIT_DESC, ITEM_DELETE)
 - **FULL_MANAGE**: All management permissions  
 - **FULL_DATA**: All data permissions
 - **FULL_ACCESS**: All access permissions
@@ -149,7 +150,7 @@ For entities with items (slots, packing items, drivers), permissions work with i
 - If an item doesn't grant a permission, the parent entity's permission is checked
 - This is handled by `itemAllow(id, key, parentKey)` which checks item first, then parent
 
-Example: To edit a packing item, you need ITEM_EDIT on the item itself OR ITEM_EDIT on the parent packing list.
+Example: To edit a packing item, you need ITEM_EDIT on the item itself OR ITEM_EDIT on the parent packing list. If you only need to edit item descriptions, ITEM_EDIT_DESC on the parent also works.
 
 ## Practical Examples
 

--- a/src/controller/activityController.ts
+++ b/src/controller/activityController.ts
@@ -480,7 +480,7 @@ async function updateSlotAttr(slotId: string, body: any, permData?: PermBundle) 
     if (!permData ||
         ((body.startTime !== undefined || body.endTime !== undefined) && !permData.itemAllow(slotId, "EDIT_META", "ITEM_EDIT"))
         || (body.title !== undefined && !permData.itemAllow(slotId, "EDIT_TITLE", "ITEM_EDIT"))
-        || (body.description !== undefined && !permData.itemAllow(slotId, "EDIT_DESC", "ITEM_EDIT"))
+        || (body.description !== undefined && !permData.itemAllow(slotId, "EDIT_DESC", ["ITEM_EDIT", "ITEM_EDIT_DESC"]))
         || (body.maxAssignees !== undefined && !permData.itemAllow(slotId, "EDIT_CAPACITY", "ITEM_EDIT"))
         || (body.roles !== undefined && !permData.itemAllow(slotId, "MANAGE_ASSIGNMENTS", "MANAGE_ASSIGNMENTS"))
     ) {

--- a/src/middleware/permissionMiddleware.ts
+++ b/src/middleware/permissionMiddleware.ts
@@ -152,7 +152,7 @@ function requirePermInternal(
     getSubject: (req: Request) => Promise<Subject> | Subject,
     requiredPerm: number,
     err: ErrorAdapter,
-    requiredParentPerm?: number
+    requiredParentPerm?: number | number[]
 ) {
     return async (req: Request, _res: Response, next: NextFunction) => {
         const subject = await getSubject(req);
@@ -177,11 +177,11 @@ export function requirePermission(getEntity: EntityGetter, requiredPerm: number)
 }
 
 /** Item version (with parent). You may pass a different requiredParentPerm; if omitted, same perm is checked on parent. */
-export function requireItemPermissionApi(get: ItemWithParentGetter, requiredPerm: number, requiredParentPerm?: number) {
+export function requireItemPermissionApi(get: ItemWithParentGetter, requiredPerm: number, requiredParentPerm?: number | number[]) {
     return requirePermInternal((req) => ({kind: 'item', ...(get(req) as any)}), requiredPerm, apiErrors, requiredParentPerm);
 }
 
-export function requireItemPermission(get: ItemWithParentGetter, requiredPerm: number, requiredParentPerm?: number) {
+export function requireItemPermission(get: ItemWithParentGetter, requiredPerm: number, requiredParentPerm?: number | number[]) {
     return requirePermInternal((req) => ({kind: 'item', ...(get(req) as any)}), requiredPerm, expectedErrors, requiredParentPerm);
 }
 

--- a/src/modules/permissionEngine.ts
+++ b/src/modules/permissionEngine.ts
@@ -100,11 +100,18 @@ async function computeMaskFor(
 function makePermView(mask: number, parentMask: number): PermView {
     const selfHas = (k: PermType) => hasPerm(mask, PERM[k]);
     const parentHas = (k: PermType) => hasPerm(parentMask, PERM[k]);
+
     return {
         mask,
         parentMask,
         has: selfHas,
-        allow: (k, parentKey) => selfHas(k) || parentHas(parentKey ?? k),
+        allow: (k, parentKey) => {
+            const parentKeys = parentKey !== undefined
+                ? (Array.isArray(parentKey) ? parentKey : [parentKey])
+                : [k];
+
+            return selfHas(k) || parentKeys.some(parentHas);
+        },
         all: (...keys) => keys.every(selfHas),
         any: (...keys) => keys.some(selfHas),
         bits: Object.fromEntries(Object.keys(PERM).map(k => [k, hasPerm(mask, (PERM as any)[k])]))
@@ -179,7 +186,7 @@ export async function buildPermBundle(
         items: itemMap,
         item: getItem,
         itemHas: (id: string, key: keyof typeof PERM) => getItem(id).has(key),
-        itemAllow: (id: string, key: keyof typeof PERM, parentKey?: keyof typeof PERM) => getItem(id).allow(key, parentKey),
+        itemAllow: (id: string, key: keyof typeof PERM, parentKey?: keyof typeof PERM | (keyof typeof PERM)[]) => getItem(id).allow(key, parentKey),
     };
 
     bundle.toJSON = () => JSON.stringify({entity: bundle.entity, items: bundle.items}, jsonReplacer);
@@ -192,7 +199,7 @@ export async function can(
     subject: Subject,
     session: SessionLike,
     requiredPerm: number,
-    requiredParentPerm?: number
+    requiredParentPerm?: number | number[]
 ): Promise<boolean> {
     const view = await evaluateSubject(subject, session, {
         participant: new Map(),
@@ -203,11 +210,12 @@ export async function can(
     // self
     if (hasPerm(view.mask, requiredPerm)) return true;
 
-    // item: optionally allow via parent
-    if (requiredParentPerm && hasPerm(view.parentMask, requiredParentPerm)) return true;
+    const parentPerms = requiredParentPerm !== undefined
+        ? (Array.isArray(requiredParentPerm) ? requiredParentPerm : [requiredParentPerm])
+        : [requiredPerm];
 
-    // default fallback: same perm on parent if subject is item and no parentRequiredPerm specified
-    if ('parentMask' in view && hasPerm(view.parentMask, requiredParentPerm ?? requiredPerm)) return true;
+    // item: optionally allow via parent
+    if ('parentMask' in view && parentPerms.some((perm) => hasPerm(view.parentMask, perm))) return true;
 
     return false;
 }

--- a/src/public/js/core/permissions.ts
+++ b/src/public/js/core/permissions.ts
@@ -34,7 +34,13 @@ function restorePermView(data: Partial<PermView>, parentData?: Partial<PermView>
         mask: data.mask!,
         parentMask: data.parentMask!,
         has: selfHas,
-        allow: (k, parentKey) => selfHas(k) || parentHas(k),
+        allow: (k, parentKey) => {
+            const parentKeys = parentKey !== undefined
+                ? (Array.isArray(parentKey) ? parentKey : [parentKey])
+                : [k];
+
+            return selfHas(k) || parentKeys.some(parentHas);
+        },
         all: (...keys) => keys.every(selfHas),
         any: (...keys) => keys.some(selfHas),
         bits: data.bits!
@@ -62,7 +68,7 @@ function restorePermBundle(data: Partial<PermBundle>): PermBundle {
         items: itemMap,
         item: getItem,
         itemHas: (id: string, key: PermType) => getItem(id).has(key),
-        itemAllow: (id: string, key: PermType, parentKey?: PermType) => getItem(id).allow(key, parentKey),
+        itemAllow: (id: string, key: PermType, parentKey?: PermType | PermType[]) => getItem(id).allow(key, parentKey),
     };
 
     return bundle;
@@ -149,13 +155,19 @@ export function requireEntityPermsForForm(formData: FormData, rules: EntityFormR
  * @param action Human readable action for error messages
  * @param parentKey Optional parent permission to fall back to
  */
-export function requireItemPerm(itemId: string, key: PermType, action: string, parentKey?: PermType): void {
+export function requireItemPerm(
+    itemId: string,
+    key: PermType,
+    action: string,
+    parentKey?: PermType | PermType[],
+): void {
     const perms = ensurePermData();
     if (!itemId) {
         throw new Error('Missing item context for permission check.');
     }
     if (!perms.itemAllow(itemId, key, parentKey)) {
-        const permName = formatPerm(parentKey ?? key);
+        const parentDisplay = Array.isArray(parentKey) ? parentKey[0] : parentKey;
+        const permName = formatPerm(parentDisplay ?? key);
         throw new Error(`You need ${permName} permission to ${action}.`);
     }
 }

--- a/src/public/js/modules/activity-slot-editor.ts
+++ b/src/public/js/modules/activity-slot-editor.ts
@@ -6,7 +6,7 @@
 import {post} from '../core/http';
 import {showInlineAlert} from '../shared/alerts';
 import {reloadAfterDelay} from '../shared/ui-helpers';
-import {requireEntityPerm, requireItemPerm} from '../core/permissions';
+import {getPerms, requireEntityPerm, requireItemPerm} from '../core/permissions';
 import {addRoleToGlobal, getAllRoles, getSlotRolesForSlot} from './activity-roles';
 import type {BootstrapGlobal, RoleSummary, SlotEditorMode} from './activity-types';
 
@@ -63,6 +63,14 @@ export function initSlotEditorModal(planId: string): void {
         }
     };
 
+    const getEditCapabilities = (slotId: string) => {
+        const perms = getPerms();
+        const allowMeta = perms?.itemAllow(slotId, 'EDIT_META', 'ITEM_EDIT') ?? false;
+        const allowDesc = perms?.itemAllow(slotId, 'EDIT_DESC', ['ITEM_EDIT', 'ITEM_EDIT_DESC']) ?? false;
+
+        return {allowMeta, allowDesc};
+    };
+
     const toTimeInputValue = (dbTime?: string | null): string => {
         if (!dbTime) return '';
         const parts = dbTime.split(':');
@@ -80,10 +88,42 @@ export function initSlotEditorModal(planId: string): void {
         return `${value}:00`;
     };
 
+    const titleGroup = titleInput?.closest<HTMLElement>('.mb-3') ?? undefined;
+    const timeRow = startInput?.closest<HTMLElement>('.row') ?? undefined;
+    const capacityGroup = capacityInput?.closest<HTMLElement>('.mb-3') ?? undefined;
+    const descGroup = descInput?.closest<HTMLElement>('.mb-3') ?? undefined;
+    const roleGroup = roleChips?.closest<HTMLElement>('.mb-3') ?? undefined;
+
     const setSelectedRoles = (ids: number[]) => {
         selectedRoleIds = new Set(ids);
         renderRoleChips();
         updateRoleSuggestions();
+    };
+
+    const applyEditMode = (allowMeta: boolean, allowDesc: boolean) => {
+        const descOnly = allowDesc && !allowMeta;
+
+        const toggleHidden = (el: HTMLElement | undefined, hidden: boolean) => {
+            if (!el) return;
+            el.classList.toggle('d-none', hidden);
+        };
+
+        if (titleInput) {
+            titleInput.required = allowMeta;
+            titleInput.readOnly = !allowMeta;
+        }
+        [startInput, endInput, capacityInput, roleInput].forEach((el) => {
+            if (el) el.disabled = !allowMeta;
+        });
+        if (descInput) {
+            descInput.readOnly = !(allowDesc || allowMeta);
+        }
+
+        toggleHidden(titleGroup, descOnly);
+        toggleHidden(timeRow, descOnly);
+        toggleHidden(capacityGroup, descOnly);
+        toggleHidden(roleGroup, descOnly);
+        toggleHidden(descGroup, !(allowDesc || allowMeta));
     };
 
     const renderRoleChips = () => {
@@ -222,6 +262,8 @@ export function initSlotEditorModal(planId: string): void {
         clearRoleInput();
         hideRoleSuggestions();
 
+        applyEditMode(true, true);
+
         modal.show();
         titleInput.focus();
     };
@@ -235,6 +277,12 @@ export function initSlotEditorModal(planId: string): void {
 
         slotIdInput.value = slotId;
         dateInput.value = date;
+
+        const {allowMeta, allowDesc} = getEditCapabilities(slotId);
+        if (!allowMeta && !allowDesc) {
+            showInlineAlert('error', 'You are not allowed to edit this slot.');
+            return;
+        }
 
         const titleSpan = slotEl.querySelector<HTMLElement>('[data-edit="title"]');
         const descSpan = slotEl.querySelector<HTMLElement>('[data-edit="description"]');
@@ -267,8 +315,10 @@ export function initSlotEditorModal(planId: string): void {
         clearRoleInput();
         hideRoleSuggestions();
 
+        applyEditMode(allowMeta, allowDesc);
+
         modal.show();
-        titleInput.focus();
+        (allowMeta ? titleInput : descInput)?.focus();
     };
 
     const createRoleOnServer = async (name: string): Promise<RoleSummary> => {
@@ -328,15 +378,26 @@ export function initSlotEditorModal(planId: string): void {
                 showInlineAlert('success', 'Slot created');
             } else {
                 const slotId = slotIdInput.value;
-                requireItemPerm(slotId, 'ITEM_EDIT', 'edit slots', 'ITEM_EDIT');
-                await post(`/api/activity/${planId}/slot/${slotId}/attr`, {
-                    title: titleValue,
-                    description: descInput?.value?.trim() || '',
-                    startTime: startVal,
-                    endTime: endVal,
-                    maxAssignees: capacityInput.value,
-                    roles: roleIds,
-                });
+                const {allowMeta, allowDesc} = getEditCapabilities(slotId);
+
+                if (allowMeta) {
+                    requireItemPerm(slotId, 'EDIT_META', 'edit slots', 'ITEM_EDIT');
+                    await post(`/api/activity/${planId}/slot/${slotId}/attr`, {
+                        title: titleValue,
+                        description: descInput?.value?.trim() || '',
+                        startTime: startVal,
+                        endTime: endVal,
+                        maxAssignees: capacityInput.value,
+                        roles: roleIds,
+                    });
+                } else if (allowDesc) {
+                    requireItemPerm(slotId, 'EDIT_DESC', 'edit slot descriptions', ['ITEM_EDIT', 'ITEM_EDIT_DESC']);
+                    await post(`/api/activity/${planId}/slot/${slotId}/description`, {
+                        description: descInput?.value?.trim() || '',
+                    });
+                } else {
+                    throw new Error('Permission denied');
+                }
                 showInlineAlert('success', 'Slot updated');
             }
 

--- a/src/public/js/shared/inline-edit.ts
+++ b/src/public/js/shared/inline-edit.ts
@@ -14,7 +14,7 @@ interface InlineEditPermission {
     key: PermType;
     action: string;
     itemId?: string;
-    parentKey?: PermType;
+    parentKey?: PermType | PermType[];
 }
 
 interface InlineEditAreaOptions {
@@ -163,7 +163,7 @@ export function startInlineEdit(elem: HTMLElement, baseUrl: string): void {
     }
 
     const fieldGuard: Record<string, InlineEditPermission> = {
-        description: {scope: 'item', key: 'EDIT_DESC', action: 'edit descriptions', itemId: id, parentKey: 'ITEM_EDIT'},
+        description: {scope: 'item', key: 'EDIT_DESC', action: 'edit descriptions', itemId: id, parentKey: ['ITEM_EDIT', 'ITEM_EDIT_DESC']},
         default: {scope: 'item', key: 'EDIT_META', action: 'edit item details', itemId: id, parentKey: 'ITEM_EDIT'}
     };
 

--- a/src/routes/api/activity.ts
+++ b/src/routes/api/activity.ts
@@ -188,7 +188,7 @@ app.post('/:id/slot/add', requirePermissionApi(permFct, PERM.ITEM_ADD), asyncHan
     renderer.respondWithSuccessJson(res, msg);
 }));
 
-app.post('/:id/slot/:slotId/description', requireItemPermissionApi(permFctItems, PERM.EDIT_DESC, PERM.ITEM_EDIT), asyncHandler(async (req: Request, res: Response) => {
+app.post('/:id/slot/:slotId/description', requireItemPermissionApi(permFctItems, PERM.EDIT_DESC, [PERM.ITEM_EDIT, PERM.ITEM_EDIT_DESC]), asyncHandler(async (req: Request, res: Response) => {
     const msg = await controller.updateSlotDescription(req.params.slotId, req.body);
     renderer.respondWithSuccessJson(res, msg);
 }));

--- a/src/routes/api/drivers.ts
+++ b/src/routes/api/drivers.ts
@@ -68,7 +68,7 @@ app.post('/:id/items', requirePermissionApi(permFct, PERM.ITEM_ADD), asyncHandle
     renderer.respondWithSuccessJson(res, msg);
 }));
 
-app.post('/:id/item/:itemId/description', requireItemPermissionApi(permFctItems, PERM.EDIT_DESC, PERM.ITEM_EDIT), asyncHandler(async (req: Request, res: Response) => {
+app.post('/:id/item/:itemId/description', requireItemPermissionApi(permFctItems, PERM.EDIT_DESC, [PERM.ITEM_EDIT, PERM.ITEM_EDIT_DESC]), asyncHandler(async (req: Request, res: Response) => {
     const msg = await controller.updateItemDescription(req.params.itemId, req.body);
     renderer.respondWithSuccessJson(res, msg);
 }));

--- a/src/routes/api/packing.ts
+++ b/src/routes/api/packing.ts
@@ -68,7 +68,7 @@ app.post('/:id/items', requirePermissionApi(permFct, PERM.ITEM_ADD), asyncHandle
     renderer.respondWithSuccessJson(res, msg);
 }));
 
-app.post('/:id/item/:itemId/description', requireItemPermissionApi(permFctItems, PERM.EDIT_DESC, PERM.ITEM_EDIT), asyncHandler(async (req: Request, res: Response) => {
+app.post('/:id/item/:itemId/description', requireItemPermissionApi(permFctItems, PERM.EDIT_DESC, [PERM.ITEM_EDIT, PERM.ITEM_EDIT_DESC]), asyncHandler(async (req: Request, res: Response) => {
     const msg = await controller.updateItemDescription(req.params.itemId, req.body);
     renderer.respondWithSuccessJson(res, msg);
 }));

--- a/src/types/PermissionTypes.d.ts
+++ b/src/types/PermissionTypes.d.ts
@@ -84,7 +84,11 @@ export type PermBundle = {
     items: Map<string, PermView>,
     item: (id: string) => PermView,
     itemHas: (id: string, key: keyof typeof PERM) => boolean,
-    itemAllow: (id: string, key: keyof typeof PERM, parentKey?: keyof typeof PERM) => boolean,
+    itemAllow: (
+        id: string,
+        key: keyof typeof PERM,
+        parentKey?: keyof typeof PERM | (keyof typeof PERM)[]
+    ) => boolean,
     toJSON?: () => string,
 }
 
@@ -99,7 +103,7 @@ export type PermView = {
     mask: number;
     parentMask: number;
     has: (k: keyof typeof PERM) => boolean;              // self only
-    allow: (k: keyof typeof PERM, parentKey?: keyof typeof PERM) => boolean; // self OR parent
+    allow: (k: keyof typeof PERM, parentKey?: keyof typeof PERM | (keyof typeof PERM)[]) => boolean; // self OR parent
     all: (...keys: (keyof typeof PERM)[]) => boolean;    // all on self
     any: (...keys: (keyof typeof PERM)[]) => boolean;    // any on self
     bits: Record<string, boolean>;                       // quick flags

--- a/src/views/activity/parts/schedule.pug
+++ b/src/views/activity/parts/schedule.pug
@@ -95,6 +95,7 @@ each week in weeks
 
                                         // ── Header: title + time + admin controls
                                         .d-flex.justify-content-between.align-items-start.mb-0
+                                            - const canEditSlot = permData.itemAllow(slot.id, 'EDIT_META', 'ITEM_EDIT') || permData.itemAllow(slot.id, 'EDIT_DESC', ['ITEM_EDIT', 'ITEM_EDIT_DESC'])
                                             if permData.itemAllow(slot.id, 'ITEM_EDIT', 'ITEM_EDIT')
                                                 i.bi.bi-grip-vertical.text-bg-dark.me-2(
                                                     title="Drag to reorder")
@@ -117,7 +118,7 @@ each week in weeks
                                                     class=overbooked ? 'bg-danger' : empty ? 'bg-warning' : 'bg-success'
                                                     style="width:0.7rem;height:0.7rem;display:inline-block;"
                                                     title=overbooked ? 'Overbooked' : empty ? 'No assignments yet' : 'OK')
-                                                if permData.itemAllow(slot.id, 'ITEM_EDIT', 'ITEM_EDIT') || permData.entity.has('ITEM_EDIT_DESC')
+                                                if canEditSlot
                                                     button.btn.btn-sm.btn-outline-light(
                                                         type="button"
                                                         data-slot-edit

--- a/src/views/drivers/drivers-view.pug
+++ b/src/views/drivers/drivers-view.pug
@@ -82,7 +82,7 @@ block content
                         td= item.driverName
 
                         // Description
-                        if permData.itemAllow(item.id, 'EDIT_DESC', 'ITEM_EDIT')
+                        if permData.itemAllow(item.id, 'EDIT_DESC', ['ITEM_EDIT', 'ITEM_EDIT_DESC'])
                             td(data-edit="description" data-id=item.id)= item.description
                         else
                             td= item.description

--- a/src/views/packing/packing-view.pug
+++ b/src/views/packing/packing-view.pug
@@ -112,7 +112,7 @@ block content
                             td= item.title
 
                         // Description
-                        if permData.itemAllow(item.id, 'EDIT_DESC', 'ITEM_EDIT')
+                        if permData.itemAllow(item.id, 'EDIT_DESC', ['ITEM_EDIT', 'ITEM_EDIT_DESC'])
                             td(data-edit="description" data-id=item.id)= item.description
                         else
                             td= item.description

--- a/tests/client/unit/activity-slot-editor.test.ts
+++ b/tests/client/unit/activity-slot-editor.test.ts
@@ -46,71 +46,73 @@ describe('activity-slot-editor', () => {
             mockShow.mockClear();
             mockHide.mockClear();
 
-        // Setup basic modal structure
-        modal = document.createElement('div');
-        modal.id = 'slotEditorModal';
+            // Setup basic modal structure
+            modal = document.createElement('div');
+            modal.id = 'slotEditorModal';
 
-        form = document.createElement('form');
-        form.id = 'slotEditorForm';
+            form = document.createElement('form');
+            form.id = 'slotEditorForm';
 
-        const titleEl = document.createElement('h5');
-        titleEl.id = 'slotEditorTitle';
+            const titleEl = document.createElement('h5');
+            titleEl.id = 'slotEditorTitle';
 
-        const slotIdInput = document.createElement('input');
-        slotIdInput.id = 'slotEditorSlotId';
+            const slotIdInput = document.createElement('input');
+            slotIdInput.id = 'slotEditorSlotId';
 
-        const dateInput = document.createElement('input');
-        dateInput.id = 'slotEditorDate';
+            const dateInput = document.createElement('input');
+            dateInput.id = 'slotEditorDate';
 
-        const titleInput = document.createElement('input');
-        titleInput.id = 'slotEditorTitleInput';
+            const titleInput = document.createElement('input');
+            titleInput.id = 'slotEditorTitleInput';
 
-        const descInput = document.createElement('textarea');
-        descInput.id = 'slotEditorDescription';
+            const descInput = document.createElement('textarea');
+            descInput.id = 'slotEditorDescription';
 
-        const startInput = document.createElement('input');
-        startInput.id = 'slotEditorStartTime';
+            const startInput = document.createElement('input');
+            startInput.id = 'slotEditorStartTime';
 
-        const endInput = document.createElement('input');
-        endInput.id = 'slotEditorEndTime';
+            const endInput = document.createElement('input');
+            endInput.id = 'slotEditorEndTime';
 
-        const capacityInput = document.createElement('input');
-        capacityInput.id = 'slotEditorCapacity';
+            const capacityInput = document.createElement('input');
+            capacityInput.id = 'slotEditorCapacity';
 
-        const metaSpan = document.createElement('span');
-        metaSpan.id = 'slotEditorMeta';
+            const metaSpan = document.createElement('span');
+            metaSpan.id = 'slotEditorMeta';
 
-        const errorSpan = document.createElement('span');
-        errorSpan.id = 'slotEditorError';
-        errorSpan.classList.add('d-none');
+            const errorSpan = document.createElement('span');
+            errorSpan.id = 'slotEditorError';
+            errorSpan.classList.add('d-none');
 
-        const roleChips = document.createElement('div');
-        roleChips.id = 'slotEditorRoleChips';
+            const roleChips = document.createElement('div');
+            roleChips.id = 'slotEditorRoleChips';
 
-        const roleInput = document.createElement('input');
-        roleInput.id = 'slotEditorRoleInput';
+            const roleInput = document.createElement('input');
+            roleInput.id = 'slotEditorRoleInput';
 
-        const roleSuggestions = document.createElement('div');
-        roleSuggestions.id = 'slotEditorRoleSuggestions';
-        roleSuggestions.classList.add('d-none');
+            const roleSuggestions = document.createElement('div');
+            roleSuggestions.id = 'slotEditorRoleSuggestions';
+            roleSuggestions.classList.add('d-none');
 
-        form.append(slotIdInput, dateInput, titleInput, descInput, startInput, endInput, capacityInput);
-        modal.append(titleEl, form, metaSpan, errorSpan, roleChips, roleInput, roleSuggestions);
-        document.body.append(modal);
+            form.append(slotIdInput, dateInput, titleInput, descInput, startInput, endInput, capacityInput);
+            modal.append(titleEl, form, metaSpan, errorSpan, roleChips, roleInput, roleSuggestions);
+            document.body.append(modal);
 
-        mockPost = jest.spyOn(http, 'post').mockResolvedValue({
-            status: 'success',
-            data: {slotId: 'newSlot'},
-        });
+            mockPost = jest.spyOn(http, 'post').mockResolvedValue({
+                status: 'success',
+                data: {slotId: 'newSlot'},
+            });
 
-        jest.spyOn(alerts, 'showInlineAlert').mockImplementation();
-        jest.spyOn(uiHelpers, 'reloadAfterDelay').mockImplementation();
-        jest.spyOn(permissions, 'requireEntityPerm').mockImplementation();
-        jest.spyOn(permissions, 'requireItemPerm').mockImplementation();
-        jest.spyOn(activityRoles, 'getAllRoles').mockReturnValue(testData.roleManagement.multipleRoles);
-        jest.spyOn(activityRoles, 'getSlotRolesForSlot').mockReturnValue([]);
-        jest.spyOn(activityRoles, 'addRoleToGlobal').mockImplementation();
-        }
+            jest.spyOn(alerts, 'showInlineAlert').mockImplementation();
+            jest.spyOn(uiHelpers, 'reloadAfterDelay').mockImplementation();
+            jest.spyOn(permissions, 'requireEntityPerm').mockImplementation();
+            jest.spyOn(permissions, 'requireItemPerm').mockImplementation();
+            const permsMock = {itemAllow: jest.fn().mockReturnValue(true)};
+            jest.spyOn(permissions, 'getPerms').mockReturnValue(permsMock as any);
+            jest.spyOn(activityRoles, 'getAllRoles').mockReturnValue(testData.roleManagement.multipleRoles);
+            jest.spyOn(activityRoles, 'getSlotRolesForSlot').mockReturnValue([]);
+            jest.spyOn(activityRoles, 'addRoleToGlobal').mockImplementation();
+        },
     });
 
     describe('initialization', () => {
@@ -477,9 +479,45 @@ describe('activity-slot-editor', () => {
 
             expect(permissions.requireItemPerm).toHaveBeenCalledWith(
                 testData.slotEditing.existing.slotId,
-                'ITEM_EDIT',
+                'EDIT_META',
                 'edit slots',
                 'ITEM_EDIT'
+            );
+        });
+
+        test('allows description-only edits when user lacks full edit rights', async () => {
+            const descOnlyPerms = {
+                itemAllow: (_id: string, key: string) => key === 'EDIT_DESC',
+            } as any;
+            (permissions.getPerms as jest.Mock).mockReturnValue(descOnlyPerms);
+
+            const editBtn = document.createElement('button');
+            editBtn.dataset.slotEdit = '1';
+            slotEl.append(editBtn);
+
+            editBtn.click();
+
+            const titleInput = document.getElementById('slotEditorTitleInput') as HTMLInputElement;
+            const startInput = document.getElementById('slotEditorStartTime') as HTMLInputElement;
+            const descInput = document.getElementById('slotEditorDescription') as HTMLTextAreaElement;
+
+            expect(titleInput.required).toBe(false);
+            expect(startInput.disabled).toBe(true);
+
+            descInput.value = 'Updated description';
+
+            form.dispatchEvent(new Event('submit'));
+            await new Promise((resolve) => setTimeout(resolve, 100));
+
+            expect(permissions.requireItemPerm).toHaveBeenCalledWith(
+                testData.slotEditing.existing.slotId,
+                'EDIT_DESC',
+                'edit slot descriptions',
+                ['ITEM_EDIT', 'ITEM_EDIT_DESC']
+            );
+            expect(mockPost).toHaveBeenCalledWith(
+                `/api/activity/plan123/slot/${testData.slotEditing.existing.slotId}/description`,
+                {description: 'Updated description'}
             );
         });
     });

--- a/tests/client/unit/permissions.test.ts
+++ b/tests/client/unit/permissions.test.ts
@@ -249,6 +249,28 @@ describe('permissions utilities', () => {
                 requireItemPerm('item1', 'EDIT', 'edit item', 'MANAGE');
             }).toThrow('You need Manage permission to edit item.');
         });
+
+        test('allows description edits when parent has ITEM_EDIT_DESC', () => {
+            const rawPerms = {
+                entity: {
+                    mask: 0,
+                    parentMask: 0,
+                    bits: {ITEM_EDIT_DESC: true},
+                },
+                items: {
+                    dataType: 'Map',
+                    value: [['item1', {mask: 0, parentMask: 0, bits: {}}]],
+                },
+            } as any;
+
+            window.Surveyor.rawPermissions = JSON.stringify(rawPerms);
+            loadPerms();
+
+            expect(() => requireItemPerm('item1', 'EDIT_DESC', 'edit item descriptions', ['ITEM_EDIT', 'ITEM_EDIT_DESC'])).not.toThrow();
+
+            window.Surveyor.rawPermissions = undefined;
+            window.Surveyor.permissions = undefined;
+        });
     });
 
     describe('requireEntityPermsForForm', () => {

--- a/tests/unit/permissionEngine-item-desc.test.ts
+++ b/tests/unit/permissionEngine-item-desc.test.ts
@@ -1,0 +1,62 @@
+import {buildPermBundle, can} from '../../src/modules/permissionEngine';
+import {PERM} from '../../src/modules/lib/permissions';
+import * as entityAdminService from '../../src/modules/database/services/EntityAdminService';
+
+jest.mock('../../src/modules/database/services/EntityAdminService', () => ({
+    getUserPerms: jest.fn(),
+    getDefaultPerms: jest.fn().mockResolvedValue({}),
+    updatePerms: jest.fn(),
+}));
+
+jest.mock('../../src/modules/database/services/EventService', () => ({
+    isRegisteredForEvent: jest.fn().mockResolvedValue(false),
+}));
+
+describe('item description parent permission', () => {
+    const getUserPerms = entityAdminService.getUserPerms as jest.Mock;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('can allows description edits when parent has ITEM_EDIT_DESC', async () => {
+        getUserPerms.mockImplementation((_type: string, id: string) =>
+            id === 'parent-1' ? PERM.ITEM_EDIT_DESC : 0
+        );
+
+        const subject = {
+            kind: 'item',
+            item: {entityType: 'packingItem', entityId: 'item-1'},
+            parent: {entityType: 'packing', entityId: 'parent-1'},
+        } as any;
+
+        const result = await can(subject, {user: {id: 42}}, PERM.EDIT_DESC, [PERM.ITEM_EDIT, PERM.ITEM_EDIT_DESC]);
+
+        expect(result).toBe(true);
+    });
+
+    test('entity description still requires EDIT_DESC on the entity', async () => {
+        getUserPerms.mockResolvedValue(PERM.ITEM_EDIT_DESC);
+
+        const subject = {kind: 'entity', entity: {entityType: 'packing', entityId: 'parent-1'}} as any;
+
+        const result = await can(subject, {user: {id: 42}}, PERM.EDIT_DESC);
+
+        expect(result).toBe(false);
+    });
+
+    test('perm bundle allows item descriptions via ITEM_EDIT_DESC fallback', async () => {
+        getUserPerms.mockImplementation((_type: string, id: string) =>
+            id === 'parent-1' ? PERM.ITEM_EDIT_DESC : 0
+        );
+
+        const bundle = await buildPermBundle(
+            {entityType: 'packing', entityId: 'parent-1'} as any,
+            [{entityType: 'packingItem', entityId: 'item-1'}] as any,
+            {user: {id: 42}}
+        );
+
+        expect(bundle.itemAllow('item-1', 'EDIT_DESC', ['ITEM_EDIT', 'ITEM_EDIT_DESC'])).toBe(true);
+        expect(bundle.entity.has('EDIT_DESC')).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
- show the slot pencil button when description editing is allowed and hide other fields for description-only access
- route pencil edits without full slot permissions through the description endpoint and guard permissions accordingly
- extend activity slot editor unit tests to cover description-only editing

## Testing
- npx jest --config jest.client.config.ts --runTestsByPath tests/client/unit/activity-slot-editor.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939e37152b483328bc5644037b18891)