### PR TITLE
Improve participant override UX

### DIFF
--- a/src/controller/activityController.ts
+++ b/src/controller/activityController.ts
@@ -573,7 +573,17 @@ async function getRequirements(planId: string) {
         assignments,
     );
 
-    return {...requirementConfig, participants};
+    const overrideTargets = eventParticipants.map((participant) => ({
+        key: participant.userId ? `user:${participant.userId}` : `guest:${participant.guestId}`,
+        userId: participant.userId ?? null,
+        guestId: participant.guestId ?? null,
+        label: participant.name
+            || (participant.userId ? `User #${participant.userId}` : participant.guestId ? `Guest #${participant.guestId}` : 'Participant'),
+        arrivalDate: participant.arrivalDate ?? null,
+        departureDate: participant.departureDate ?? null,
+    }));
+
+    return {...requirementConfig, participants, overrideTargets};
 }
 
 async function calculateBaselineRequirement(planId: string) {
@@ -608,6 +618,29 @@ async function calculateBaselineRequirement(planId: string) {
 
 async function updateRequirements(planId: string, body: any) {
     const {roleRequirements, overrides, ...planSettings} = preprocessRequirementUpdate(body);
+    const plan = await activityService.getActivityPlanById(planId);
+
+    if (!plan) {
+        throw new APIError('Activity plan not found', {planId}, 404);
+    }
+    if (!plan.event?.id) {
+        throw new APIError('Event is required to configure participant overrides', {planId}, 400);
+    }
+
+    const eventParticipants = await eventService.getEventParticipants(plan.event.id);
+    const allowedUsers = new Set(eventParticipants.map((p) => p.userId).filter((id): id is number => id != null));
+    const allowedGuests = new Set(eventParticipants.map((p) => p.guestId).filter((id): id is number => id != null));
+
+    const invalidOverride = overrides.find((override) => {
+        if (override.userId) return !allowedUsers.has(override.userId);
+        if (override.guestId) return !allowedGuests.has(override.guestId);
+        return false;
+    });
+
+    if (invalidOverride) {
+        throw new APIError('Overrides must target participants registered for this event', invalidOverride, 400);
+    }
+
     // Convert bindingDeadline string to Date if present
     const normalizedSettings: Partial<Pick<ActivityPlan, "assignmentMode" | "generalRequiredShifts" | "roundingMode" | "bindingDeadline" | "allowOverfillAfterFull" | "allowArrivalDayEvening" | "allowDepartureDayMorning">> = {
         assignmentMode: planSettings.assignmentMode,

--- a/src/public/js/modules/activity-requirements.ts
+++ b/src/public/js/modules/activity-requirements.ts
@@ -239,11 +239,11 @@ export function initRequirementPanel(planId: string): void {
     const buildOverrideRow = (override?: RequirementConfiguration['overrides'][number]) => {
         if (!overrideList) return;
         const row = document.createElement('div');
-        row.className = 'row g-3 align-items-start override-row border border-secondary-subtle rounded p-3';
+        row.className = 'row align-items-start override-row border border-secondary-subtle rounded p-2';
         if (override?.id) row.dataset.overrideId = String(override.id);
 
         const colTarget = document.createElement('div');
-        colTarget.className = 'col-lg-5 col-md-6 d-grid gap-1';
+        colTarget.className = 'col-md-5 d-grid gap-1 m-auto';
         const targetLabel = document.createElement('label');
         targetLabel.className = 'form-label small mb-0';
         targetLabel.textContent = 'Participant';
@@ -282,13 +282,13 @@ export function initRequirementPanel(planId: string): void {
             const missingOpt = document.createElement('option');
             missingOpt.value = overrideValue;
             missingOpt.dataset.invalid = 'true';
-            missingOpt.textContent = override?.user?.username
+            missingOpt.textContent = override?.user?.name || override?.user?.username
                 || override?.guest?.username
                 || `Not registered (${overrideValue.replace(':', ' #')})`;
             participantSelect.append(missingOpt);
             participantSelect.value = overrideValue;
         } else if (participantSelect.querySelector('option:not([disabled])')) {
-            participantSelect.value = participantSelect.querySelector('option:not([disabled])')?.value || '';
+            participantSelect.value = participantSelect.querySelector<HTMLOptionElement>('option:not([disabled])')?.value || '';
         }
 
         if (!overrideTargets?.length) {
@@ -303,7 +303,7 @@ export function initRequirementPanel(planId: string): void {
         colTarget.append(targetLabel, participantSelect, targetHint);
 
         const colRole = document.createElement('div');
-        colRole.className = 'col-lg-4 col-md-6 d-grid gap-1';
+        colRole.className = 'col-md-3 d-grid gap-1 m-auto';
         const roleLabel = document.createElement('label');
         roleLabel.className = 'form-label small mb-0';
         roleLabel.textContent = 'Role (optional)';
@@ -317,7 +317,7 @@ export function initRequirementPanel(planId: string): void {
         colRole.append(roleLabel, roleSelect);
 
         const colReq = document.createElement('div');
-        colReq.className = 'col-md-3 d-grid gap-1';
+        colReq.className = 'col-md-3 d-grid gap-1 m-auto';
         const reqLabel = document.createElement('label');
         reqLabel.className = 'form-label small mb-0';
         reqLabel.textContent = 'Required shifts';
@@ -330,7 +330,7 @@ export function initRequirementPanel(planId: string): void {
         colReq.append(reqLabel, reqInput);
 
         const colRemove = document.createElement('div');
-        colRemove.className = 'col-md-2 d-flex align-items-end';
+        colRemove.className = 'col-md-1 d-flex align-items-end m-auto py-3';
         const removeBtn = document.createElement('button');
         removeBtn.type = 'button';
         removeBtn.className = 'btn btn-sm btn-outline-danger w-100';
@@ -432,7 +432,7 @@ export function initRequirementPanel(planId: string): void {
             .filter((v): v is { roleId: number; requiredShifts: number } => Boolean(v));
     };
 
-    const collectOverrides = (): {overrides: RequirementConfiguration['overrides']; hasInvalid: boolean} => {
+    const collectOverrides = (): { overrides: RequirementConfiguration['overrides']; hasInvalid: boolean } => {
         if (!overrideList) return {overrides: [], hasInvalid: false};
         const entries: RequirementConfiguration['overrides'] = [];
         let hasInvalid = false;

--- a/src/public/js/modules/activity-requirements.ts
+++ b/src/public/js/modules/activity-requirements.ts
@@ -33,6 +33,8 @@ export function initRequirementPanel(planId: string): void {
     const allowArrivalEvening = panel.querySelector<HTMLInputElement>('#allowArrivalEvening');
     const allowDepartureMorning = panel.querySelector<HTMLInputElement>('#allowDepartureMorning');
     const baselineCalcBtn = panel.querySelector<HTMLButtonElement>('[data-requirements-baseline-calc]');
+    let overrideTargets: RequirementConfiguration['overrideTargets'] = [];
+    type OverrideTarget = NonNullable<RequirementConfiguration['overrideTargets']>[number];
 
     const setAlert = (message?: string, variant: 'info' | 'danger' = 'info') => {
         if (!alertBox) return;
@@ -46,6 +48,63 @@ export function initRequirementPanel(planId: string): void {
         alertBox.classList.remove('d-none', 'alert-danger', 'alert-info');
         alertBox.classList.add(variant === 'danger' ? 'alert-danger' : 'alert-info');
         target.textContent = message;
+    };
+
+    const participantValue = (target?: OverrideTarget) => {
+        if (!target) return '';
+        if (target.userId) return `user:${target.userId}`;
+        if (target.guestId) return `guest:${target.guestId}`;
+        return target.key || '';
+    };
+
+    const findTargetForOverride = (override?: RequirementConfiguration['overrides'][number]) => {
+        if (!overrideTargets) return undefined;
+        return overrideTargets.find((target) => {
+            if (override?.userId && target.userId) return target.userId === override.userId;
+            if (override?.guestId && target.guestId) return target.guestId === override.guestId;
+            return false;
+        });
+    };
+
+    const describeAttendance = (target?: OverrideTarget) => {
+        if (!target) return '';
+        const arrival = target.arrivalDate ? formatDateLabel(target.arrivalDate) : '';
+        const departure = target.departureDate ? formatDateLabel(target.departureDate) : '';
+        if (arrival || departure) return `${arrival || 'start'} – ${departure || 'end'}`;
+        return 'Full event attendance';
+    };
+
+    const updateParticipantHint = (select?: HTMLSelectElement | null, hint?: HTMLElement | null) => {
+        if (!select || !hint) return;
+        const option = select.selectedOptions[0];
+        if (!select.value) {
+            hint.classList.remove('text-warning');
+            hint.classList.add('text-secondary');
+            hint.textContent = 'Select a registered participant to override requirements.';
+            return;
+        }
+
+        if (option?.dataset.invalid === 'true') {
+            hint.classList.remove('text-secondary');
+            hint.classList.add('text-warning');
+            hint.textContent = 'Not registered for this event. Choose a different participant.';
+            return;
+        }
+
+        const target = overrideTargets?.find((t) => participantValue(t) === select.value);
+        const attendance = describeAttendance(target);
+        hint.classList.remove('text-warning');
+        hint.classList.add('text-secondary');
+        const badge = target?.userId ? 'User' : 'Guest';
+        hint.textContent = attendance ? `${badge} • ${attendance}` : badge;
+    };
+
+    const setOverrideControlsState = () => {
+        if (!addOverrideBtn) return;
+        addOverrideBtn.disabled = !overrideTargets || !overrideTargets.length;
+        addOverrideBtn.title = addOverrideBtn.disabled
+            ? 'Register participants for this event to enable overrides'
+            : '';
     };
 
     const updateRequirementSummaryStats = (summary: RequirementParticipantSummary[] = []) => {
@@ -180,39 +239,71 @@ export function initRequirementPanel(planId: string): void {
     const buildOverrideRow = (override?: RequirementConfiguration['overrides'][number]) => {
         if (!overrideList) return;
         const row = document.createElement('div');
-        row.className = 'row g-2 align-items-center override-row';
+        row.className = 'row g-3 align-items-start override-row border border-secondary-subtle rounded p-3';
         if (override?.id) row.dataset.overrideId = String(override.id);
 
         const colTarget = document.createElement('div');
-        colTarget.className = 'col-md-3 d-grid gap-1';
+        colTarget.className = 'col-lg-5 col-md-6 d-grid gap-1';
         const targetLabel = document.createElement('label');
         targetLabel.className = 'form-label small mb-0';
-        targetLabel.textContent = 'Participant type';
-        const targetSelect = document.createElement('select');
-        targetSelect.className = 'form-select form-select-sm text-bg-dark';
-        targetSelect.dataset.overrideTarget = 'type';
-        targetSelect.innerHTML = '<option value="user">User</option><option value="guest">Guest</option>';
-        if (override?.guestId) targetSelect.value = 'guest';
+        targetLabel.textContent = 'Participant';
+        const participantSelect = document.createElement('select');
+        participantSelect.className = 'form-select form-select-sm text-bg-dark';
+        participantSelect.dataset.overrideTarget = 'participant';
 
-        const targetId = document.createElement('input');
-        targetId.type = 'number';
-        targetId.min = '1';
-        targetId.className = 'form-control form-control-sm text-bg-dark';
-        targetId.dataset.overrideTarget = 'id';
-        targetId.placeholder = 'User/Guest ID';
-        targetId.value = override?.userId?.toString() || override?.guestId?.toString() || '';
+        const placeholder = document.createElement('option');
+        placeholder.value = '';
+        placeholder.disabled = true;
+        placeholder.selected = true;
+        placeholder.textContent = overrideTargets?.length
+            ? 'Choose a participant'
+            : 'No participants available';
+        participantSelect.append(placeholder);
 
-        if (override?.user?.username || override?.guest?.username) {
-            const hint = document.createElement('small');
-            hint.className = 'text-secondary';
-            hint.textContent = `Current: ${override.user?.username || override.guest?.username}`;
-            colTarget.append(targetLabel, targetSelect, targetId, hint);
-        } else {
-            colTarget.append(targetLabel, targetSelect, targetId);
+        const sortedTargets = [...(overrideTargets || [])].sort((a, b) => a.label.localeCompare(b.label));
+        sortedTargets.forEach((target) => {
+            const opt = document.createElement('option');
+            opt.value = participantValue(target);
+            const attendance = describeAttendance(target);
+            opt.textContent = attendance ? `${target.label} — ${attendance}` : target.label;
+            participantSelect.append(opt);
+        });
+
+        const overrideValue = override?.userId
+            ? `user:${override.userId}`
+            : override?.guestId
+                ? `guest:${override.guestId}`
+                : '';
+
+        const matchedTarget = findTargetForOverride(override);
+        if (matchedTarget) {
+            participantSelect.value = participantValue(matchedTarget);
+        } else if (overrideValue) {
+            const missingOpt = document.createElement('option');
+            missingOpt.value = overrideValue;
+            missingOpt.dataset.invalid = 'true';
+            missingOpt.textContent = override?.user?.username
+                || override?.guest?.username
+                || `Not registered (${overrideValue.replace(':', ' #')})`;
+            participantSelect.append(missingOpt);
+            participantSelect.value = overrideValue;
+        } else if (participantSelect.querySelector('option:not([disabled])')) {
+            participantSelect.value = participantSelect.querySelector('option:not([disabled])')?.value || '';
         }
 
+        if (!overrideTargets?.length) {
+            participantSelect.disabled = true;
+        }
+
+        const targetHint = document.createElement('div');
+        targetHint.className = 'form-text text-secondary small';
+        updateParticipantHint(participantSelect, targetHint);
+        participantSelect.addEventListener('change', () => updateParticipantHint(participantSelect, targetHint));
+
+        colTarget.append(targetLabel, participantSelect, targetHint);
+
         const colRole = document.createElement('div');
-        colRole.className = 'col-md-4 d-grid gap-1';
+        colRole.className = 'col-lg-4 col-md-6 d-grid gap-1';
         const roleLabel = document.createElement('label');
         roleLabel.className = 'form-label small mb-0';
         roleLabel.textContent = 'Role (optional)';
@@ -254,7 +345,19 @@ export function initRequirementPanel(planId: string): void {
     const renderOverrides = (config: RequirementConfiguration) => {
         if (!overrideList) return;
         overrideList.innerHTML = '';
-        if (!config.overrides.length) {
+
+        if (!overrideTargets?.length) {
+            const empty = document.createElement('div');
+            empty.className = 'text-secondary small';
+            empty.dataset.emptyState = 'true';
+            empty.textContent = 'No event participants are registered yet. Add participants to enable overrides.';
+            overrideList.append(empty);
+            if (!config.overrides.length) {
+                return;
+            }
+        }
+
+        if (overrideTargets?.length && !config.overrides.length) {
             const empty = document.createElement('div');
             empty.className = 'text-secondary small';
             empty.dataset.emptyState = 'true';
@@ -277,6 +380,9 @@ export function initRequirementPanel(planId: string): void {
         if (allowOverfill) allowOverfill.checked = Boolean(config.plan.allowOverfillAfterFull);
         if (allowArrivalEvening) allowArrivalEvening.checked = Boolean(config.plan.allowArrivalDayEvening ?? true);
         if (allowDepartureMorning) allowDepartureMorning.checked = Boolean(config.plan.allowDepartureDayMorning ?? true);
+
+        overrideTargets = config.overrideTargets || [];
+        setOverrideControlsState();
 
         buildRoleRequirementInputs(config);
         renderOverrides(config);
@@ -326,18 +432,29 @@ export function initRequirementPanel(planId: string): void {
             .filter((v): v is { roleId: number; requiredShifts: number } => Boolean(v));
     };
 
-    const collectOverrides = (): RequirementConfiguration['overrides'] => {
-        if (!overrideList) return [];
+    const collectOverrides = (): {overrides: RequirementConfiguration['overrides']; hasInvalid: boolean} => {
+        if (!overrideList) return {overrides: [], hasInvalid: false};
         const entries: RequirementConfiguration['overrides'] = [];
+        let hasInvalid = false;
         overrideList.querySelectorAll<HTMLElement>('.override-row').forEach((row) => {
-            const typeSelect = row.querySelector<HTMLSelectElement>('[data-override-target="type"]');
-            const idInput = row.querySelector<HTMLInputElement>('[data-override-target="id"]');
+            const participantSelect = row.querySelector<HTMLSelectElement>('[data-override-target="participant"]');
             const roleSelect = row.querySelector<HTMLSelectElement>('[data-override-target="role"]');
             const reqInput = row.querySelector<HTMLInputElement>('[data-override-target="required"]');
 
             const requiredShifts = Number(reqInput?.value ?? 0);
-            const idVal = idInput?.value.trim();
-            if (!typeSelect || !idVal) return;
+            const selection = participantSelect?.value ?? '';
+            const selectedOption = participantSelect?.selectedOptions[0];
+            if (!selection) return;
+            if (selectedOption?.dataset.invalid === 'true') {
+                hasInvalid = true;
+                participantSelect?.classList.add('is-invalid');
+                return;
+            }
+            participantSelect?.classList.remove('is-invalid');
+
+            const [targetType, rawId] = selection.split(':');
+            const participantId = Number(rawId);
+            if (!targetType || Number.isNaN(participantId)) return;
 
             const entry: any = {
                 roleId: roleSelect?.value ? Number(roleSelect.value) : null,
@@ -346,20 +463,27 @@ export function initRequirementPanel(planId: string): void {
 
             if (row.dataset.overrideId) entry.id = Number(row.dataset.overrideId);
 
-            if (typeSelect.value === 'guest') {
-                entry.guestId = Number(idVal);
+            if (targetType === 'guest') {
+                entry.guestId = participantId;
             } else {
-                entry.userId = Number(idVal);
+                entry.userId = participantId;
             }
 
             entries.push(entry);
         });
-        return entries;
+        return {overrides: entries, hasInvalid};
     };
 
     const saveRequirements = async () => {
         setAlert('Saving settings…');
         try {
+            const {overrides, hasInvalid} = collectOverrides();
+            if (hasInvalid) {
+                setAlert('Update overrides to target registered participants only.', 'danger');
+                showInlineAlert('error', 'Update overrides to target registered participants only.');
+                return;
+            }
+
             await post(`/api/activity/${planId}/requirements`, {
                 assignmentMode: assignmentMode?.value,
                 generalRequiredShifts: generalRequired?.value ? Number(generalRequired.value) : null,
@@ -369,7 +493,7 @@ export function initRequirementPanel(planId: string): void {
                 allowArrivalDayEvening: allowArrivalEvening?.checked ?? true,
                 allowDepartureDayMorning: allowDepartureMorning?.checked ?? true,
                 roleRequirements: collectRoleRequirements(),
-                overrides: collectOverrides(),
+                overrides,
             });
 
             showInlineAlert('success', 'Requirement settings saved');
@@ -382,6 +506,7 @@ export function initRequirementPanel(planId: string): void {
     };
 
     addOverrideBtn?.addEventListener('click', () => {
+        if (!overrideTargets?.length) return;
         if (overrideList && overrideList.querySelector('[data-empty-state]')) {
             overrideList.innerHTML = '';
         }
@@ -393,4 +518,3 @@ export function initRequirementPanel(planId: string): void {
 
     void loadRequirements();
 }
-

--- a/src/public/js/modules/activity-types.d.ts
+++ b/src/public/js/modules/activity-types.d.ts
@@ -86,6 +86,15 @@ export interface RequirementParticipantSummary {
     };
 }
 
+export interface RequirementOverrideTarget {
+    key: string;
+    label: string;
+    userId?: number | null;
+    guestId?: number | null;
+    arrivalDate?: string | null;
+    departureDate?: string | null;
+}
+
 export interface RequirementConfiguration {
     plan: {
         assignmentMode?: 'FREE' | 'REQUIRED';
@@ -97,6 +106,7 @@ export interface RequirementConfiguration {
         allowDepartureDayMorning?: boolean;
     };
     roleRequirements: { roleId: number; requiredShifts: number }[];
+    overrideTargets?: RequirementOverrideTarget[];
     overrides: {
         id?: number;
         roleId?: number | null;

--- a/src/views/activity/parts/assignments.pug
+++ b/src/views/activity/parts/assignments.pug
@@ -80,7 +80,8 @@ if permData.entity.has('MANAGE_REQUIREMENTS') && data.plan.eventId
                         i.bi.bi-plus-lg.me-1
                         | Add override
                 p.text-secondary.small.mb-2
-                    | Specify user-specific required shifts and optional roles to override the general rule.
+                    | Specify event participant-specific required shifts and optional roles to override the general rule.
+                    |  Only registered participants are eligible for overrides.
                 .d-grid.gap-2#overrideList
 
     hr

--- a/tests/client/data/activityRequirementsData.ts
+++ b/tests/client/data/activityRequirementsData.ts
@@ -25,6 +25,23 @@ const baseHTML = `
     </div>
 `;
 
+const mockOverrideTargets = [
+    {
+        key: 'user:10',
+        userId: 10,
+        label: 'John Doe',
+        arrivalDate: '2025-01-01',
+        departureDate: '2025-01-05'
+    },
+    {
+        key: 'guest:11',
+        guestId: 11,
+        label: 'Guest Greta',
+        arrivalDate: null,
+        departureDate: null
+    }
+];
+
 const mockConfig = {
     plan: {
         assignmentMode: 'FREE',
@@ -39,6 +56,7 @@ const mockConfig = {
         {roleId: 1, requiredShifts: 2},
         {roleId: 2, requiredShifts: 1}
     ],
+    overrideTargets: mockOverrideTargets,
     overrides: [],
     participants: []
 };
@@ -54,6 +72,12 @@ const mockConfigWithOverrides = {
             requiredShifts: 5
         }
     ]
+};
+
+const mockConfigWithoutTargets = {
+    ...mockConfig,
+    overrideTargets: [],
+    overrides: []
 };
 
 const mockConfigWithParticipants = {
@@ -168,6 +192,15 @@ const _activityRequirementsData = {
                 mockData: mockConfig,
                 hasEmptyState: true,
                 expectedRows: 0
+            },
+            {
+                description: 'disables override creation when no participants available',
+                planId: 'plan1',
+                html: baseHTML,
+                mockData: mockConfigWithoutTargets,
+                hasEmptyState: true,
+                expectedRows: 0,
+                expectDisabledAdd: true
             },
             {
                 description: 'renders override rows when overrides exist',

--- a/tests/client/unit/activity-requirements.test.ts
+++ b/tests/client/unit/activity-requirements.test.ts
@@ -112,7 +112,7 @@ describe('activity-requirements module', () => {
     });
 
     describe('overrides rendering', () => {
-        test.each(activityRequirementsData().overrides.render)('$description', async ({planId, html, mockData, hasEmptyState, expectedRows}) => {
+        test.each(activityRequirementsData().overrides.render)('$description', async ({planId, html, mockData, hasEmptyState, expectedRows, expectDisabledAdd}) => {
             document.body.innerHTML = html;
             mockGet.mockResolvedValue({data: mockData});
             
@@ -122,6 +122,7 @@ describe('activity-requirements module', () => {
             await new Promise(resolve => setTimeout(resolve, 10));
             
             const overrideList = document.getElementById('overrideList');
+            const addBtn = document.querySelector('[data-add-override]') as HTMLButtonElement | null;
             
             if (hasEmptyState) {
                 const emptyState = overrideList?.querySelector('[data-empty-state]');
@@ -129,6 +130,10 @@ describe('activity-requirements module', () => {
             } else {
                 const rows = overrideList?.querySelectorAll('.override-row');
                 expect(rows?.length).toBe(expectedRows);
+            }
+
+            if (expectDisabledAdd !== undefined) {
+                expect(addBtn?.disabled).toBe(expectDisabledAdd);
             }
         });
 


### PR DESCRIPTION
## Summary
- return event participant override targets for activity requirements and validate override targets against event registrations
- refresh the participant override UI to use participant dropdowns with attendance context, disable creation when no event participants exist, and guard against invalid selections
- expand client requirements tests with participant fixtures and disabled state coverage

## Testing
- npm run test:client

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947ca7e90648332bf6421dc69494757)