### PR TITLE
docs: migrate testing guidance and test types from Jest to Playwright Test

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -50,13 +50,21 @@ The project uses **data-driven** and **keyword-driven** testing approaches. For 
 ```typescript
 // Import data and keywords
 import { testData } from '../data/controller/featureData';
-import { setupMock, verifyResult } from '../keywords/common/controllerKeywords';
+import { test } from '@playwright/test';
+import { createAsyncFake, verifyResult } from '../keywords/common/controllerKeywords';
 
 // Data-driven test
-test.each(testData)('$description', async (testCase) => {
-    setupMock(service.method, testCase.expected);
-    const result = await controller.method(testCase.input);
-    verifyResult(result, testCase.expected);
+test.describe('feature controller', () => {
+    for (const testCase of testData) {
+        test(testCase.description, async ({}, testInfo) => {
+            await test.step(`run ${testInfo.title}`, async () => {
+                const methodFake = createAsyncFake<[FeatureInput], Feature>(testCase.expected);
+                service.method = methodFake.fn;
+                const result = await controller.method(testCase.input);
+                verifyResult(result, testCase.expected);
+            });
+        });
+    }
 });
 ```
 

--- a/.github/copilot/project-overview.md
+++ b/.github/copilot/project-overview.md
@@ -5,8 +5,7 @@ Surveyor is a TypeScript-based survey management application built with:
 - Express.js for the web server
 - TypeORM for database operations
 - MariaDB as the database
-- Jest for unit and integration testing
-- Playwright for end-to-end testing
+- Playwright Test for unit, integration, and end-to-end testing
 - Pug for templating
 - Bootstrap for styling
 
@@ -25,7 +24,6 @@ Surveyor is a TypeScript-based survey management application built with:
 ### Key Development Dependencies
 
 - typescript - Type checking and compilation
-- jest - Testing framework
-- @playwright/test - E2E testing
+- @playwright/test - Testing framework
 - ts-node - TypeScript execution
 - supertest - HTTP testing

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,7 +23,7 @@ Surveyor is a **monolithic web application** for survey and event management wit
 - **Database**: MariaDB with TypeORM
 - **Frontend**: Server-rendered Pug templates + vanilla JavaScript/TypeScript
 - **Authentication**: OIDC (OpenID Connect)
-- **Testing**: Jest + Playwright
+- **Testing**: Playwright Test
 
 ### High-Level Architecture
 
@@ -89,8 +89,7 @@ Surveyor is a **monolithic web application** for survey and event management wit
 
 | Technology | Version | Purpose |
 |------------|---------|---------|
-| Jest | Latest | Unit/integration testing |
-| Playwright | Latest | E2E testing |
+| Playwright Test | Latest | Unit, integration, and E2E testing |
 | MSW | Latest | API mocking |
 | Testing Library | Latest | DOM testing |
 
@@ -444,8 +443,17 @@ export const createSurveyData = [
 ];
 
 // tests/controller/survey.test.ts
-test.each(createSurveyData)('$description', async (testCase) => {
-    // Test implementation
+import {test, expect} from '@playwright/test';
+
+test.describe('create survey', () => {
+    for (const testCase of createSurveyData) {
+        test(testCase.description, async ({request}) => {
+            await test.step('create survey through the API fixture', async () => {
+                const response = await request.post('/surveys', {data: testCase.input});
+                expect(await response.json()).toEqual(testCase.expected);
+            });
+        });
+    }
 });
 ```
 
@@ -453,16 +461,25 @@ test.each(createSurveyData)('$description', async (testCase) => {
 
 ```typescript
 // tests/keywords/common/controllerKeywords.ts
-export function setupMock(mockFn: jest.Mock, returnValue: any): void {
-    mockFn.mockResolvedValue(returnValue);
+import {expect} from '@playwright/test';
+
+export interface FakeAsyncFunction<TArgs extends unknown[] = unknown[], TResult = unknown> {
+    calls: TArgs[];
+    fn: (...args: TArgs) => Promise<TResult>;
 }
 
-export function verifyResult(actual: any, expected: any): void {
+export function createAsyncFake<TArgs extends unknown[], TResult>(returnValue: TResult): FakeAsyncFunction<TArgs, TResult> {
+    const calls: TArgs[] = [];
+    return {calls, fn: async (...args: TArgs) => { calls.push(args); return returnValue; }};
+}
+
+export function verifyResult(actual: unknown, expected: unknown): void {
     expect(actual).toEqual(expected);
 }
 
 // Usage in tests
-setupMock(service.create, testCase.expected);
+const createFake = createAsyncFake<[CreateSurveyInput], Survey>(testCase.expected);
+service.create = createFake.fn;
 const result = await controller.create(testCase.input);
 verifyResult(result, testCase.expected);
 ```

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -106,7 +106,7 @@ surveyor/
 │   ├── views/                  # Pug templates
 │   └── server.ts               # Application entry point
 ├── tests/                      # Test suite
-│   ├── client/                 # Frontend tests (Jest + MSW)
+│   ├── client/                 # Frontend tests (Playwright Test + MSW)
 │   ├── controller/             # Controller tests
 │   ├── database/               # Database integration tests
 │   ├── e2e/                    # End-to-end tests (Playwright)
@@ -142,9 +142,9 @@ surveyor/
 
 4. **Run tests:**
    ```bash
-   npm test              # Fast Jest tests
+   npm run test:quick      # Fast Playwright-compatible tests
    npm run test:watch    # Watch mode
-   npm run test:all      # Full suite (Jest + E2E)
+   npm run test:all      # Full suite (unit/integration + E2E)
    ```
 
 5. **Commit your changes:**
@@ -314,8 +314,8 @@ See [TESTING_GUIDE.md](TESTING_GUIDE.md) for comprehensive testing documentation
 ### Quick Reference
 
 ```bash
-# Jest tests (fast)
-npm test                  # All Jest tests
+# Fast tests
+npm run test:quick        # Unit/integration tests
 npm run test:watch        # Watch mode
 npm run test:client       # Frontend tests only
 npm run test:debug        # With database logging
@@ -350,8 +350,20 @@ Follow these patterns:
 2. **Create or use keywords:**
    ```typescript
    // tests/keywords/common/controllerKeywords.ts
-   export function setupMock(mockFn: jest.Mock, returnValue: any): void {
-       mockFn.mockResolvedValue(returnValue);
+   import {expect} from '@playwright/test';
+
+   export interface FakeAsyncFunction<TArgs extends unknown[] = unknown[], TResult = unknown> {
+       calls: TArgs[];
+       fn: (...args: TArgs) => Promise<TResult>;
+   }
+
+   export function createAsyncFake<TArgs extends unknown[], TResult>(returnValue: TResult): FakeAsyncFunction<TArgs, TResult> {
+       const calls: TArgs[] = [];
+       return {calls, fn: async (...args: TArgs) => { calls.push(args); return returnValue; }};
+   }
+
+   export function verifyResult(actual: unknown, expected: unknown): void {
+       expect(actual).toEqual(expected);
    }
    ```
 
@@ -359,12 +371,20 @@ Follow these patterns:
    ```typescript
    // tests/controller/myFeature.test.ts
    import { createFeatureData } from '../data/controller/myFeatureData';
-   import { setupMock, verifyResult } from '../keywords/common/controllerKeywords';
+   import { test } from '@playwright/test';
+   import { createAsyncFake, verifyResult } from '../keywords/common/controllerKeywords';
    
-   test.each(createFeatureData)('$description', async (testCase) => {
-       setupMock(service.create, testCase.expected);
-       const result = await controller.create(testCase.input);
-       verifyResult(result, testCase.expected);
+   test.describe('create feature', () => {
+       for (const testCase of createFeatureData) {
+           test(testCase.description, async ({}, testInfo) => {
+               await test.step(`run ${testInfo.title}`, async () => {
+                   const createFake = createAsyncFake<[CreateFeatureInput], Feature>(testCase.expected);
+                   service.create = createFake.fn;
+                   const result = await controller.create(testCase.input);
+                   verifyResult(result, testCase.expected);
+               });
+           });
+       }
    });
    ```
 
@@ -415,16 +435,16 @@ debugger; // Breakpoint in browser devtools
 
 ```bash
 # Run specific test with debugging
-npm test -- tests/unit/myTest.test.ts --verbose
+npx playwright test tests/unit/myTest.test.ts --debug
 
 # Debug with VS Code
 # Add to launch.json:
 {
     "type": "node",
     "request": "launch",
-    "name": "Debug Jest Tests",
-    "program": "${workspaceFolder}/node_modules/.bin/jest",
-    "args": ["--runInBand", "${file}"],
+    "name": "Debug Playwright Tests",
+    "program": "${workspaceFolder}/node_modules/.bin/playwright",
+    "args": ["test", "${file}"],
     "console": "integratedTerminal"
 }
 ```
@@ -648,7 +668,7 @@ Set environment variables in deployment platform:
 rm -rf node_modules package-lock.json
 npm install
 npm run build
-npm test
+npm run test:all
 ```
 
 #### Database Connection Errors

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -50,13 +50,18 @@ export const preprocessCreateData = [
 ];
 
 // Test (in tests/controller/survey.controller.test.ts)
-test.each(preprocessCreateData)(
-    '$description',
-    ({input, expected}) => {
-        const result = preprocessCreate(input);
-        expect(result).toEqual(expected);
+import {test, expect} from '@playwright/test';
+
+test.describe('preprocessCreate', () => {
+    for (const {description, input, expected} of preprocessCreateData) {
+        test(description, async () => {
+            await test.step('preprocess survey input', async () => {
+                const result = preprocessCreate(input);
+                expect(result).toEqual(expected);
+            });
+        });
     }
-);
+});
 ```
 
 ### Keyword-Driven Testing
@@ -157,14 +162,26 @@ Keyword files export reusable test functions:
 
 ```typescript
 // tests/keywords/common/controllerKeywords.ts
-export function setupMock(mockFn: jest.Mock, returnValue?: any): void {
-    if (returnValue !== undefined) {
-        mockFn.mockResolvedValue(returnValue);
-    }
+import {expect} from '@playwright/test';
+
+export interface FakeAsyncFunction<TArgs extends unknown[] = unknown[], TResult = unknown> {
+    calls: TArgs[];
+    fn: (...args: TArgs) => Promise<TResult>;
 }
 
-export function verifyMockCall(mockFn: jest.Mock, ...args: any[]): void {
-    expect(mockFn).toHaveBeenCalledWith(...args);
+export function createAsyncFake<TArgs extends unknown[], TResult>(returnValue: TResult): FakeAsyncFunction<TArgs, TResult> {
+    const calls: TArgs[] = [];
+    return {
+        calls,
+        fn: async (...args: TArgs) => {
+            calls.push(args);
+            return returnValue;
+        },
+    };
+}
+
+export function verifyFakeCall<TArgs extends unknown[]>(fake: FakeAsyncFunction<TArgs>, ...args: TArgs): void {
+    expect(fake.calls).toContainEqual(args);
 }
 ```
 
@@ -184,38 +201,51 @@ import {verifyResult} from '../keywords/common/controllerKeywords';
 2. **Use data-driven approach**:
 
 ```typescript
-describe('toLocalISODate', () => {
-    test.each(toLocalISODateData)('$description', ({input, expected}) => {
-        const result = toLocalISODate(input);
-        verifyResult(result, expected);
-    });
+import {test} from '@playwright/test';
+
+test.describe('toLocalISODate', () => {
+    for (const {description, input, expected} of toLocalISODateData) {
+        test(description, async () => {
+            await test.step('format the date', async () => {
+                const result = toLocalISODate(input);
+                verifyResult(result, expected);
+            });
+        });
+    }
 });
 ```
 
 ### Controller Tests
 
-Controller tests verify business logic with mocked services:
+Controller tests verify business logic with framework-neutral fakes for service dependencies:
 
-1. **Setup mocks using keywords**:
+1. **Set up fakes using keywords**:
 
 ```typescript
-import {setupMock, verifyMockCall} from '../keywords/common/controllerKeywords';
+import {createAsyncFake, verifyFakeCall} from '../keywords/common/controllerKeywords';
 
-setupMock(surveyService.createSurveyTx as jest.Mock, 'survey-123');
+const createSurveyTxFake = createAsyncFake<[CreateSurveyInput], string>('survey-123');
+surveyService.createSurveyTx = createSurveyTxFake.fn;
 ```
 
 2. **Use data-driven tests**:
 
 ```typescript
-test.each(createEntityData)(
-    '$description',
-    async ({userId, payload, expectedServiceCall, mockReturnValue}) => {
-        setupMock(surveyService.createSurveyTx as jest.Mock, mockReturnValue);
-        const result = await createEntity(userId, payload);
-        verifyResult(result, mockReturnValue);
-        verifyMockCall(surveyService.createSurveyTx as jest.Mock, ...);
+import {test} from '@playwright/test';
+
+test.describe('createEntity', () => {
+    for (const {description, userId, payload, expectedServiceCall, mockReturnValue} of createEntityData) {
+        test(description, async ({}, testInfo) => {
+            await test.step(`create entity for ${testInfo.title}`, async () => {
+                const createSurveyTxFake = createAsyncFake<[CreateSurveyInput], string>(mockReturnValue);
+                surveyService.createSurveyTx = createSurveyTxFake.fn;
+                const result = await createEntity(userId, payload);
+                verifyResult(result, mockReturnValue);
+                verifyFakeCall(createSurveyTxFake, expectedServiceCall);
+            });
+        });
     }
-);
+});
 ```
 
 ### Middleware Tests
@@ -234,12 +264,15 @@ import {
 2. **Test with data**:
 
 ```typescript
-test.each(requireOwnerSuccessData)(
-    '$description',
-    async ({session, resource, additional}) => {
-        await expectMiddlewareSuccess(requireOwner(), session, resource, additional);
+test.describe('requireOwner', () => {
+    for (const {description, session, resource, additional} of requireOwnerSuccessData) {
+        test(description, async ({request}) => {
+            await test.step('verify owner middleware succeeds', async () => {
+                await expectMiddlewareSuccess(requireOwner(), session, resource, additional, request);
+            });
+        });
     }
-);
+});
 ```
 
 ### Database Tests
@@ -272,27 +305,34 @@ test('creates entity with valid data', async () => {
 **Correct approach** - Generate UUIDs at runtime:
 
 ```typescript
+import {test, expect} from '@playwright/test';
 import {v4 as uuidv4} from 'uuid';
 
-test.each(testData)('$description', async (testCase) => {
-    // Generate UUIDs for items at runtime
-    const itemIdMap = new Map<string, string>();
-    testCase.items.forEach(item => {
-        itemIdMap.set(item.id, uuidv4());
-    });
+test.describe('item UUID mapping', () => {
+    for (const testCase of testData) {
+        test(testCase.description, async () => {
+            await test.step('map readable IDs to UUIDs', async () => {
+                // Generate UUIDs for items at runtime
+                const itemIdMap = new Map<string, string>();
+                testCase.items.forEach(item => {
+                    itemIdMap.set(item.id, uuidv4());
+                });
 
-    // Map items to use real UUIDs
-    const items = testCase.items.map(item => ({
-        ...item,
-        id: itemIdMap.get(item.id)!
-    }));
+                // Map items to use real UUIDs
+                const items = testCase.items.map(item => ({
+                    ...item,
+                    id: itemIdMap.get(item.id)!,
+                }));
 
-    // Use mapped items in service calls
-    await createItems(listId, items);
+                // Use mapped items in service calls
+                await createItems(listId, items);
 
-    // Map expected results using itemIdMap
-    const expectedIds = testCase.expectedIds.map(id => itemIdMap.get(id)!);
-    expect(actualIds).toEqual(expectedIds);
+                // Map expected results using itemIdMap
+                const expectedIds = testCase.expectedIds.map(id => itemIdMap.get(id)!);
+                expect(actualIds).toEqual(expectedIds);
+            });
+        });
+    }
 });
 ```
 
@@ -441,14 +481,14 @@ await verifyFieldRequired(page, fieldName);
 ### All Tests
 
 ```bash
-npm test
+npm run test:all
 ```
 
 ### Specific Test Suite
 
 ```bash
-npm test -- tests/unit/util.test.ts
-npm test -- tests/controller/survey.controller.test.ts
+npx playwright test tests/unit/util.test.ts
+npx playwright test tests/controller/survey.controller.test.ts
 ```
 
 ### Watch Mode
@@ -460,7 +500,7 @@ npm run test:watch
 ### With Coverage
 
 ```bash
-npm test -- --coverage
+npx playwright test --reporter=html
 ```
 
 ### E2E Tests
@@ -491,10 +531,10 @@ npm run e2e:ui      # With Playwright UI
 
 ### Test Code
 
-1. **Use data-driven tests**: Prefer `test.each()` over multiple similar tests
+1. **Use data-driven tests**: Prefer iterating shared data inside `test.describe()` over duplicating similar tests
 2. **Use keywords**: Abstract common operations into reusable keywords
 3. **Clear assertions**: Use descriptive keywords like `verifyResult()`
-4. **Minimal mocking**: Mock only external dependencies
+4. **Minimal faking**: Fake only external dependencies
 5. **Clean setup/teardown**: Use `beforeEach`/`afterEach` for test isolation
 
 ### Naming Conventions
@@ -560,12 +600,18 @@ export const toLocalISODateData = [
 // tests/unit/util.test.ts
 import {toLocalISODateData} from '../data/unit/utilData';
 
-describe('toLocalISODate', () => {
-    test.each(toLocalISODateData)('$description', async ({input, expected}) => {
-        const {toLocalISODate} = await importWithMocks();
-        const result = toLocalISODate(input);
-        expect(result).toBe(expected);
-    });
+import {test, expect} from '@playwright/test';
+
+test.describe('toLocalISODate', () => {
+    for (const {description, input, expected} of toLocalISODateData) {
+        test(description, async ({}, testInfo) => {
+            await test.step(`run ${testInfo.title}`, async () => {
+                const {toLocalISODate} = await importWithFakes();
+                const result = toLocalISODate(input);
+                expect(result).toBe(expected);
+            });
+        });
+    }
 });
 ```
 
@@ -585,17 +631,23 @@ export const createEntityData = [
 
 // tests/controller/survey.controller.test.ts
 import {createEntityData} from '../data/controller/surveyData';
-import {setupMock, verifyMockCall, verifyResult} from '../keywords/common/controllerKeywords';
+import {createAsyncFake, verifyFakeCall, verifyResult} from '../keywords/common/controllerKeywords';
 
-test.each(createEntityData)(
-    '$description',
-    async ({userId, payload, expectedServiceCall, mockReturnValue}) => {
-        setupMock(surveyService.createSurveyTx as jest.Mock, mockReturnValue);
-        const result = await createEntity(userId, payload);
-        verifyResult(result, mockReturnValue);
-        verifyMockCall(surveyService.createSurveyTx as jest.Mock, ...);
+import {test} from '@playwright/test';
+
+test.describe('createEntity', () => {
+    for (const {description, userId, payload, expectedServiceCall, mockReturnValue} of createEntityData) {
+        test(description, async ({}, testInfo) => {
+            await test.step(`create entity for ${testInfo.title}`, async () => {
+                const createSurveyTxFake = createAsyncFake<[CreateSurveyInput], string>(mockReturnValue);
+                surveyService.createSurveyTx = createSurveyTxFake.fn;
+                const result = await createEntity(userId, payload);
+                verifyResult(result, mockReturnValue);
+                verifyFakeCall(createSurveyTxFake, expectedServiceCall);
+            });
+        });
     }
-);
+});
 ```
 
 ## Contributing
@@ -612,8 +664,7 @@ When contributing tests:
 
 ## Resources
 
-- [Jest Documentation](https://jestjs.io/docs/getting-started)
-- [Playwright Documentation](https://playwright.dev/)
+- [Playwright Test Documentation](https://playwright.dev/docs/test-intro)
 - [MSW Documentation](https://mswjs.io/docs/)
 - [Testing Library](https://testing-library.com/docs/)
 - [Frontend Testing Guide](tests/client/README.md)

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -5,8 +5,9 @@
     "allowSyntheticDefaultImports": true,
     "isolatedModules": true,
     "types": [
-      "jest",
-      "node"
+      "@playwright/test",
+      "node",
+      "jquery"
     ]
   },
   "include": [


### PR DESCRIPTION
### Motivation

- Remove stale Jest-specific type usage and examples and standardize on Playwright Test for unit/integration/E2E guidance. 
- Provide Playwright-compatible examples and framework-neutral fakes so new tests follow the project's E2E-first tooling and avoid importing Jest types. 

### Description

- Updated `tsconfig.test.json` to remove the `jest` ambient type and add `@playwright/test`, `node`, and `jquery` to `compilerOptions.types`. 
- Reworked `docs/TESTING_GUIDE.md`, `docs/DEVELOPMENT.md`, and `docs/ARCHITECTURE.md` to replace Jest examples (`test.each`, `jest.Mock`, etc.) with Playwright Test patterns (`import { test, expect } from '@playwright/test'`, `test.describe`, `test.step`, and fixture usage). 
- Replaced `jest.Mock` helper examples with a framework-neutral fake interface and helpers (`FakeAsyncFunction`, `createAsyncFake`, `verifyFakeCall`) in keyword examples and guidance. 
- Updated Copilot guidance and project overview files (`.github/copilot-instructions.md`, `.github/copilot/project-overview.md`) to remove Jest references and show Playwright-compatible snippets. 

### Testing

- Verified `tsconfig.test.json` is valid JSON with `node -e "JSON.parse(require('fs').readFileSync('tsconfig.test.json','utf8'))"` which succeeded. 
- Searched docs for remaining Jest references with ripgrep (`rg`) to confirm replacements and the search succeeded. 
- Ran TypeScript compile check with `npx tsc --noEmit --project tsconfig.test.json`, which failed due to pre-existing strict-null errors in client modules (these are unrelated existing issues and not caused by the documentation/type changes). 
- Ran `git diff --check` to ensure no obvious whitespace/diff errors, which returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72e8cc0bf88332bcf6058268add798)